### PR TITLE
feat: avoid vg name collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pre-NixOS Setup
 
-This project contains tools to prepare bare-metal machines for a NixOS installation. It discovers hardware, plans a storage layout, and can apply that plan.
+This project contains tools to prepare bare-metal machines for a NixOS installation. It discovers hardware, plans a storage layout, and can apply that plan. When multiple disk groups qualify for the same tier, only the largest is mounted as `main` or `large`; smaller groups receive suffixed VG names and are left unmounted for manual use after installation.
 
 ## Usage
 

--- a/automated-pre-nixos-design-changelog.md
+++ b/automated-pre-nixos-design-changelog.md
@@ -41,3 +41,6 @@
 
 ### v0.8 — 2025-09-09
 - Defined ISO configuration in flake and documented build instructions.
+
+### v0.9 — 2025-09-09
+- Clarified volume group naming: only the largest SSD/HDD bucket uses `main` or `large`; smaller buckets get suffixed names and remain unmounted.

--- a/tests/test_plan_storage.py
+++ b/tests/test_plan_storage.py
@@ -23,3 +23,28 @@ def test_plan_single_disk() -> None:
     plan = plan_storage("fast", disks)
     assert plan["arrays"] == []
     assert plan["vgs"] == [{"name": "main", "devices": ["nvme0n1"]}]
+
+
+def test_multiple_ssd_buckets_named_separately() -> None:
+    disks = [
+        Disk(name="sda", size=1000, rotational=False),
+        Disk(name="sdb", size=1000, rotational=False),
+        Disk(name="sdc", size=500, rotational=False),
+    ]
+    plan = plan_storage("fast", disks)
+    vg_names = {vg["name"] for vg in plan["vgs"]}
+    assert "main" in vg_names and "main-1" in vg_names
+    lv_vgs = {lv["vg"] for lv in plan["lvs"]}
+    assert lv_vgs == {"main"}
+
+def test_multiple_hdd_buckets_named_separately() -> None:
+    disks = [
+        Disk(name="sda", size=2000, rotational=True),
+        Disk(name="sdb", size=2000, rotational=True),
+        Disk(name="sdc", size=1000, rotational=True),
+    ]
+    plan = plan_storage("fast", disks)
+    vg_names = {vg["name"] for vg in plan["vgs"]}
+    assert "large" in vg_names and "large-1" in vg_names
+    lv_vgs = {lv["vg"] for lv in plan["lvs"]}
+    assert lv_vgs == {"large"}


### PR DESCRIPTION
## Summary
- assign base VG names only to largest disk groups and suffix smaller ones
- leave suffixed groups unmounted and clarify behavior in design docs
- cover suffixed naming for both SSD and HDD buckets with tests and README updates

## Testing
- `pytest -q`
- `nix --extra-experimental-features "nix-command flakes" flake check --no-write-lock-file`
- `nix --extra-experimental-features "nix-command flakes" build .#nixosConfigurations.pre-installer.config.system.build.isoImage` *(fails: unable to download 'bash-5.2.tar.gz')*

------
https://chatgpt.com/codex/tasks/task_e_68bd8c281f04832fbe0adc2048c6c0e2