### PR TITLE
Adjust RAID selection for HDD arrays

### DIFF
--- a/pre_nixos/planner.py
+++ b/pre_nixos/planner.py
@@ -48,22 +48,30 @@ def decide_ssd_array(group: List[Disk], mode: str) -> Dict[str, Any]:
     return {"level": level, "devices": devices}
 
 
-def decide_hdd_array(group: List[Disk]) -> Dict[str, Any]:
-    """Decide RAID configuration for HDD group."""
+def decide_hdd_array(group: List[Disk], prefer_raid6_on_four: bool = False) -> Dict[str, Any]:
+    """Decide RAID configuration for HDD group.
+
+    Uses ``raid5`` for three disks, optionally ``raid6`` for four disks when
+    ``prefer_raid6_on_four`` is ``True``, and ``raid6`` for five or more disks.
+    """
     count = len(group)
     devices = [d.name for d in group]
     if count <= 1:
         level = "single"
     elif count == 2:
         level = "raid1"
-    elif 3 <= count <= 5:
+    elif count == 3:
         level = "raid5"
+    elif count == 4:
+        level = "raid6" if prefer_raid6_on_four else "raid5"
     else:
         level = "raid6"
     return {"level": level, "devices": devices}
 
 
-def plan_storage(mode: str, disks: List[Disk]) -> Dict[str, Any]:
+def plan_storage(
+    mode: str, disks: List[Disk], prefer_raid6_on_four: bool = False
+) -> Dict[str, Any]:
     """Generate storage plan from disks and mode.
 
     The returned plan is a minimal representation with arrays, volume groups and
@@ -100,7 +108,7 @@ def plan_storage(mode: str, disks: List[Disk]) -> Dict[str, Any]:
     )
     for idx, bucket in enumerate(hdd_buckets):
         vg_name = "large" if idx == 0 else f"large-{idx}"
-        arr = decide_hdd_array(bucket)
+        arr = decide_hdd_array(bucket, prefer_raid6_on_four=prefer_raid6_on_four)
         devices = arr["devices"]
         if arr["level"] == "single":
             plan["vgs"].append({"name": vg_name, "devices": devices})

--- a/pre_nixos/pre_nixos.py
+++ b/pre_nixos/pre_nixos.py
@@ -13,10 +13,17 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument(
         "--plan-only", action="store_true", help="Only print the plan and exit"
     )
+    parser.add_argument(
+        "--prefer-raid6-on-four",
+        action="store_true",
+        help="Use RAID6 instead of RAID5 for four-disk HDD groups",
+    )
     args = parser.parse_args(argv)
 
     disks = inventory.enumerate_disks()
-    plan = planner.plan_storage(args.mode, disks)
+    plan = planner.plan_storage(
+        args.mode, disks, prefer_raid6_on_four=args.prefer_raid6_on_four
+    )
     print(json.dumps(plan, indent=2))
     if not args.plan_only:
         apply.apply_plan(plan)

--- a/tests/test_plan_storage.py
+++ b/tests/test_plan_storage.py
@@ -48,3 +48,14 @@ def test_multiple_hdd_buckets_named_separately() -> None:
     assert "large" in vg_names and "large-1" in vg_names
     lv_vgs = {lv["vg"] for lv in plan["lvs"]}
     assert lv_vgs == {"large"}
+
+
+def test_prefer_raid6_on_four_disks() -> None:
+    disks = [
+        Disk(name="sda", size=2000, rotational=True),
+        Disk(name="sdb", size=2000, rotational=True),
+        Disk(name="sdc", size=2000, rotational=True),
+        Disk(name="sdd", size=2000, rotational=True),
+    ]
+    plan = plan_storage("fast", disks, prefer_raid6_on_four=True)
+    assert any(arr["level"] == "raid6" for arr in plan["arrays"])

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -43,17 +43,21 @@ def test_t4_four_hdd_plus_ssd() -> None:
     groups = group_by_rotational_and_size(disks)
     hdd_group = groups["hdd"][0]
     assert decide_hdd_array(hdd_group)["level"] == "raid5"
+    assert (
+        decide_hdd_array(hdd_group, prefer_raid6_on_four=True)["level"]
+        == "raid6"
+    )
 
 
 def test_t5_mixed_hdd_groups() -> None:
     disks = [Disk(name="sda", size=1000, rotational=False)]
-    disks += [Disk(name=n, size=2000, rotational=True) for n in ["sdb", "sdc", "sdd", "sde"]]
-    disks += [Disk(name="sdf", size=1000, rotational=True), Disk(name="sdg", size=1000, rotational=True)]
+    disks += [Disk(name=n, size=2000, rotational=True) for n in ["sdb", "sdc", "sdd", "sde", "sdf"]]
+    disks += [Disk(name="sdg", size=1000, rotational=True), Disk(name="sdh", size=1000, rotational=True)]
     groups = group_by_rotational_and_size(disks)
     assert len(groups["hdd"]) == 2
     large_group = max(groups["hdd"], key=len)
     small_group = min(groups["hdd"], key=len)
-    assert decide_hdd_array(large_group)["level"] == "raid5"
+    assert decide_hdd_array(large_group)["level"] == "raid6"
     assert decide_hdd_array(small_group)["level"] == "raid1"
 
 


### PR DESCRIPTION
## Summary
- Add `prefer_raid6_on_four` flag so four-disk HDD groups can use RAID6
- Expose RAID6 preference on CLI and update tests accordingly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdfc64f890832fb8454a7117c93e95