### PR TITLE
Add swap VG/LV planning for two-disk HDD buckets

### DIFF
--- a/pre_nixos/apply.py
+++ b/pre_nixos/apply.py
@@ -29,6 +29,8 @@ def apply_plan(plan: Dict[str, Any], dry_run: bool = True) -> List[str]:
         commands.append(
             f"lvcreate -n {lv['name']} {lv['vg']} -l {lv['size']}"
         )
+        if lv["name"] == "swap":
+            commands.append(f"mkswap /dev/{lv['vg']}/{lv['name']}")
 
     if dry_run:
         return commands

--- a/pre_nixos/planner.py
+++ b/pre_nixos/planner.py
@@ -92,14 +92,21 @@ def plan_storage(mode: str, disks: List[Disk]) -> Dict[str, Any]:
             plan["arrays"].append({"name": name, "level": arr["level"], "devices": devices, "type": "ssd"})
             plan["vgs"].append({"name": vg_name, "devices": [name]})
 
-    # Handle HDD buckets for VG "large" and suffixed variants
+    # Handle HDD buckets for VG "large" and swap detection
     hdd_buckets = sorted(
         groups["hdd"],
         key=lambda b: sum(d.size for d in b),
         reverse=True,
     )
-    for idx, bucket in enumerate(hdd_buckets):
-        vg_name = "large" if idx == 0 else f"large-{idx}"
+    swap_done = False
+    large_idx = 0
+    for bucket in hdd_buckets:
+        if len(bucket) == 2 and not swap_done:
+            vg_name = "swap"
+            swap_done = True
+        else:
+            vg_name = "large" if large_idx == 0 else f"large-{large_idx}"
+            large_idx += 1
         arr = decide_hdd_array(bucket)
         devices = arr["devices"]
         if arr["level"] == "single":
@@ -115,5 +122,7 @@ def plan_storage(mode: str, disks: List[Disk]) -> Dict[str, Any]:
         plan["lvs"].append({"name": "root", "vg": "main", "size": "100%"})
     if any(vg["name"] == "large" for vg in plan["vgs"]):
         plan["lvs"].append({"name": "data", "vg": "large", "size": "100%"})
+    if any(vg["name"] == "swap" for vg in plan["vgs"]):
+        plan["lvs"].append({"name": "swap", "vg": "swap", "size": "100%"})
 
     return plan

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -16,3 +16,4 @@ def test_apply_plan_returns_commands() -> None:
     assert any(cmd.startswith("mdadm") for cmd in commands)
     assert any("vgcreate main" in cmd for cmd in commands)
     assert any("lvcreate -n root" in cmd for cmd in commands)
+    assert any(cmd.startswith("mkswap") for cmd in commands)

--- a/tests/test_plan_storage.py
+++ b/tests/test_plan_storage.py
@@ -13,9 +13,9 @@ def test_plan_storage_basic() -> None:
     plan = plan_storage("fast", disks)
     assert any(arr["level"] == "raid1" for arr in plan["arrays"])
     vg_names = {vg["name"] for vg in plan["vgs"]}
-    assert {"main", "large"} <= vg_names
+    assert {"main", "swap"} <= vg_names
     lv_names = {lv["name"] for lv in plan["lvs"]}
-    assert {"root", "data"} <= lv_names
+    assert {"root", "swap"} <= lv_names
 
 
 def test_plan_single_disk() -> None:
@@ -45,6 +45,6 @@ def test_multiple_hdd_buckets_named_separately() -> None:
     ]
     plan = plan_storage("fast", disks)
     vg_names = {vg["name"] for vg in plan["vgs"]}
-    assert "large" in vg_names and "large-1" in vg_names
+    assert "swap" in vg_names and "large" in vg_names
     lv_vgs = {lv["vg"] for lv in plan["lvs"]}
-    assert lv_vgs == {"large"}
+    assert lv_vgs == {"swap", "large"}


### PR DESCRIPTION
## Summary
- detect two-disk HDD groups and create a `swap` VG with a `swap` LV in the storage plan
- apply planning now emits `mkswap` for swap logical volumes
- expand storage planning tests to cover swap VG/LV and update apply tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdfc58475c832f96591124fe9c3f1e