### PR TITLE
Add disk partitioning utility and CLI option

### DIFF
--- a/pre_nixos/__init__.py
+++ b/pre_nixos/__init__.py
@@ -1,5 +1,5 @@
 """Pre-NixOS setup package."""
 
-__all__ = ["inventory", "planner", "apply", "network"]
+__all__ = ["inventory", "planner", "apply", "network", "partition"]
 
 __version__ = "0.1.0"

--- a/pre_nixos/partition.py
+++ b/pre_nixos/partition.py
@@ -1,0 +1,58 @@
+"""Disk partitioning utilities."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import List
+
+
+def create_partitions(
+    device: str,
+    *,
+    with_efi: bool = True,
+    efi_size: str = "512MiB",
+    dry_run: bool = True,
+) -> List[str]:
+    """Create a GPT with optional EFI and LVM partitions.
+
+    When ``with_efi`` is ``True`` the layout is:
+    * Partition 1: EFI System (type EF00) of ``efi_size``.
+    * Partition 2: Linux LVM (type 8E00) using the remaining space.
+
+    Otherwise a single Linux LVM partition spanning the whole disk is
+    created.
+
+    Parameters:
+        device: Disk device path (e.g. ``/dev/sda``).
+        with_efi: Whether to create a small EFI partition.
+        efi_size: Size of the EFI system partition.
+        dry_run: If ``True``, commands are returned instead of executed.
+
+    Returns:
+        List of shell command strings representing the operations.
+    """
+    cmds = [f"sgdisk --zap-all {device}"]
+
+    if with_efi:
+        cmds.extend(
+            [
+                f"sgdisk -n1:0:+{efi_size} -t1:EF00 {device}",
+                f"sgdisk -n2:0:0 -t2:8E00 {device}",
+                f"parted -s {device} set 1 boot on",
+                f"parted -s {device} set 2 lvm on",
+            ]
+        )
+    else:
+        cmds.extend(
+            [
+                f"sgdisk -n1:0:0 -t1:8E00 {device}",
+                f"parted -s {device} set 1 lvm on",
+            ]
+        )
+
+    if dry_run:
+        return cmds
+
+    for cmd in cmds:
+        subprocess.check_call(cmd.split())
+    return []

--- a/pre_nixos/pre_nixos.py
+++ b/pre_nixos/pre_nixos.py
@@ -3,7 +3,7 @@
 import argparse
 import json
 
-from . import inventory, planner, apply
+from . import inventory, planner, apply, partition
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -13,7 +13,24 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument(
         "--plan-only", action="store_true", help="Only print the plan and exit"
     )
+    parser.add_argument(
+        "--partition-boot",
+        metavar="DISK",
+        help="Partition boot disk with EFI and LVM",
+    )
+    parser.add_argument(
+        "--partition-lvm",
+        metavar="DISK",
+        action="append",
+        default=[],
+        help="Partition disk with a single LVM partition (can be repeated)",
+    )
     args = parser.parse_args(argv)
+
+    if args.partition_boot:
+        partition.create_partitions(args.partition_boot)
+    for dev in args.partition_lvm:
+        partition.create_partitions(dev, with_efi=False)
 
     disks = inventory.enumerate_disks()
     plan = planner.plan_storage(args.mode, disks)

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -1,0 +1,44 @@
+"""Tests for partitioning utilities."""
+
+from pre_nixos import partition, pre_nixos
+from pre_nixos.inventory import Disk
+
+
+def test_create_partitions_with_efi():
+    cmds = partition.create_partitions("/dev/sda")
+    assert cmds[0] == "sgdisk --zap-all /dev/sda"
+    assert "sgdisk -n1:0:+512MiB -t1:EF00 /dev/sda" in cmds
+    assert "sgdisk -n2:0:0 -t2:8E00 /dev/sda" in cmds
+    assert "parted -s /dev/sda set 1 boot on" in cmds
+    assert "parted -s /dev/sda set 2 lvm on" in cmds
+
+
+def test_create_partitions_lvm_only():
+    cmds = partition.create_partitions("/dev/sdb", with_efi=False)
+    assert cmds[0] == "sgdisk --zap-all /dev/sdb"
+    assert "sgdisk -n1:0:0 -t1:8E00 /dev/sdb" in cmds
+    assert "parted -s /dev/sdb set 1 lvm on" in cmds
+    assert all("EF00" not in c for c in cmds)
+
+
+def test_cli_partition_invoked(monkeypatch):
+    monkeypatch.setattr(
+        pre_nixos.inventory,
+        "enumerate_disks",
+        lambda: [Disk(name="sda", size=1000, rotational=False)],
+    )
+    called = []
+
+    def fake_part(dev, *, with_efi=True, efi_size="512MiB", dry_run=True):
+        called.append((dev, with_efi))
+        return []
+
+    monkeypatch.setattr(pre_nixos.partition, "create_partitions", fake_part)
+    pre_nixos.main([
+        "--partition-boot",
+        "/dev/sda",
+        "--partition-lvm",
+        "/dev/sdb",
+        "--plan-only",
+    ])
+    assert called == [("/dev/sda", True), ("/dev/sdb", False)]


### PR DESCRIPTION
## Summary
- allow `create_partitions` to skip EFI creation for LVM-only disks
- expose `--partition-boot` and repeatable `--partition-lvm` flags for explicit disk layouts
- extend tests for LVM-only partitioning and CLI invocation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdfc5d2c38832fb54c5e1fbd7a34da