### PR TITLE
feat(apply): pvcreate raid devices before vgcreate

### DIFF
--- a/pre_nixos/apply.py
+++ b/pre_nixos/apply.py
@@ -21,6 +21,9 @@ def apply_plan(plan: Dict[str, Any], dry_run: bool = True) -> List[str]:
             f"mdadm --create /dev/{array['name']} --level={array['level']} {devices}"
         )
 
+    for array in plan.get("arrays", []):
+        commands.append(f"pvcreate /dev/{array['name']}")
+
     for vg in plan.get("vgs", []):
         devs = " ".join(f"/dev/{d}" for d in vg["devices"])
         commands.append(f"vgcreate {vg['name']} {devs}")

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -14,5 +14,27 @@ def test_apply_plan_returns_commands() -> None:
     plan = plan_storage("fast", disks)
     commands = apply_plan(plan)
     assert any(cmd.startswith("mdadm") for cmd in commands)
+    assert any(cmd.startswith("pvcreate") for cmd in commands)
     assert any("vgcreate main" in cmd for cmd in commands)
     assert any("lvcreate -n root" in cmd for cmd in commands)
+
+
+def test_apply_plan_handles_swap() -> None:
+    plan = {
+        "arrays": [
+            {"name": "md0", "level": "raid1", "devices": ["sdb", "sdc"]}
+        ],
+        "vgs": [
+            {"name": "swap", "devices": ["md0"]}
+        ],
+        "lvs": [
+            {"name": "swap", "vg": "swap", "size": "100%"}
+        ],
+    }
+    commands = apply_plan(plan)
+    assert "pvcreate /dev/md0" in commands
+    assert "vgcreate swap /dev/md0" in commands
+    assert "lvcreate -n swap swap -l 100%" in commands
+    assert commands.index("pvcreate /dev/md0") < commands.index(
+        "vgcreate swap /dev/md0"
+    )


### PR DESCRIPTION
## Summary
- run pvcreate on RAID arrays before creating volume groups
- test pvcreate ordering and swap VG/LV creation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdfc5f513c832fa22b2db262fa9564