### PR TITLE
Format logical volumes and mount by label

### DIFF
--- a/pre_nixos/apply.py
+++ b/pre_nixos/apply.py
@@ -29,6 +29,14 @@ def apply_plan(plan: Dict[str, Any], dry_run: bool = True) -> List[str]:
         commands.append(
             f"lvcreate -n {lv['name']} {lv['vg']} -l {lv['size']}"
         )
+        lv_path = f"/dev/{lv['vg']}/{lv['name']}"
+        # The Nix store contains millions of small files. Using a dense
+        # inode allocation (1 inode per 2 KiB) prevents running out of
+        # inodes long before the LV is full.
+        commands.append(f"mkfs.ext4 -i 2048 {lv_path}")
+        commands.append(f"e2label {lv_path} {lv['name']}")
+        mount_point = "/mnt" if lv["name"] == "root" else f"/mnt/{lv['name']}"
+        commands.append(f"mount -L {lv['name']} {mount_point}")
 
     if dry_run:
         return commands

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -1,0 +1,25 @@
+"""Tests for filesystem related commands in apply_plan."""
+
+from pre_nixos.inventory import Disk
+from pre_nixos.planner import plan_storage
+from pre_nixos.apply import apply_plan
+
+
+def test_filesystem_commands_for_lvs() -> None:
+    disks = [
+        Disk(name="sda", size=1000, rotational=False),
+        Disk(name="sdb", size=2000, rotational=True),
+        Disk(name="sdc", size=2000, rotational=True),
+    ]
+    plan = plan_storage("fast", disks)
+    commands = apply_plan(plan)
+
+    # mkfs.ext4 uses a 2 KiB bytes-per-inode ratio to avoid inode exhaustion
+    # in the Nix store which contains many small files.
+    assert f"mkfs.ext4 -i 2048 /dev/main/root" in commands
+    assert f"e2label /dev/main/root root" in commands
+    assert f"mount -L root /mnt" in commands
+
+    assert f"mkfs.ext4 -i 2048 /dev/large/data" in commands
+    assert f"e2label /dev/large/data data" in commands
+    assert f"mount -L data /mnt/data" in commands


### PR DESCRIPTION
## Summary
- format logical volumes as ext4 with inode ratio 2048 for plentiful inodes
- label each LV and mount using its label
- add filesystem tests for new commands

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdfc33f134832f82afa2d4a8f53a11