### PR TITLE
Add systemd link rule to rename active NIC to lan

### DIFF
--- a/pre_nixos/network.py
+++ b/pre_nixos/network.py
@@ -23,3 +23,30 @@ def identify_lan(net_path: Path = Path("/sys/class/net")) -> Optional[str]:
         if carrier == "1":
             return iface.name
     return None
+
+
+def write_lan_rename_rule(
+    net_path: Path = Path("/sys/class/net"),
+    rules_dir: Path = Path("/etc/systemd/network"),
+) -> Optional[Path]:
+    """Persistently rename the detected LAN interface to ``lan``.
+
+    Parameters:
+        net_path: Path to ``/sys/class/net`` for interface discovery.
+        rules_dir: Directory where the systemd ``.link`` file will be written.
+
+    Returns:
+        Path to the written rule file or ``None`` if no active interface is found.
+    """
+
+    iface = identify_lan(net_path)
+    if iface is None:
+        return None
+
+    rules_dir.mkdir(parents=True, exist_ok=True)
+    rule_path = rules_dir / "10-lan.link"
+    rule_path.write_text(
+        f"[Match]\nOriginalName={iface}\n\n[Link]\nName=lan\n",
+        encoding="utf-8",
+    )
+    return rule_path

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,6 +1,6 @@
 """Tests for network module."""
 
-from pre_nixos.network import identify_lan
+from pre_nixos.network import identify_lan, write_lan_rename_rule
 
 
 def test_identify_lan(tmp_path):
@@ -10,3 +10,22 @@ def test_identify_lan(tmp_path):
         (iface / "device").mkdir()
         (iface / "carrier").write_text(carrier)
     assert identify_lan(tmp_path) == "eth1"
+
+
+def test_write_lan_rename_rule(tmp_path):
+    for name, carrier in ("eth0", "0"), ("eth1", "1"):
+        iface = tmp_path / name
+        iface.mkdir()
+        (iface / "device").mkdir()
+        (iface / "carrier").write_text(carrier)
+
+    rules_dir = tmp_path / "etc/systemd/network"
+    path = write_lan_rename_rule(tmp_path, rules_dir)
+    assert path == rules_dir / "10-lan.link"
+    assert path.read_text() == "[Match]\nOriginalName=eth1\n\n[Link]\nName=lan\n"
+
+
+def test_write_lan_rename_rule_no_iface(tmp_path):
+    rules_dir = tmp_path / "etc/systemd/network"
+    assert write_lan_rename_rule(tmp_path, rules_dir) is None
+    assert not (rules_dir / "10-lan.link").exists()


### PR DESCRIPTION
## Summary
- add `write_lan_rename_rule` to emit a systemd .link file renaming the active NIC to `lan`
- cover rule generation and failure cases with new tests

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdfc2efcf4832fac2fd4d84b195ec7