### PR TITLE
test: ensure single swap lv

### DIFF
--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -10,6 +10,7 @@ def test_filesystem_commands_for_lvs() -> None:
         Disk(name="sda", size=1000, rotational=False),
         Disk(name="sdb", size=2000, rotational=True),
         Disk(name="sdc", size=2000, rotational=True),
+        Disk(name="sdd", size=1000, rotational=True),
     ]
     plan = plan_storage("fast", disks)
     commands = apply_plan(plan)

--- a/tests/test_plan_storage.py
+++ b/tests/test_plan_storage.py
@@ -85,6 +85,18 @@ def test_single_hdd_with_ssd_gets_swap_vg() -> None:
     assert all(p["type"] == "linux-raid" for p in plan["partitions"]["sdb"])
 
 
+def test_only_one_swap_lv() -> None:
+    disks = [
+        Disk(name="sda", size=1000, rotational=False),
+        Disk(name="sdb", size=2000, rotational=True),
+        Disk(name="sdc", size=2000, rotational=True),
+        Disk(name="sdd", size=1000, rotational=True),
+    ]
+    plan = plan_storage("fast", disks)
+    swap_lvs = [lv for lv in plan["lvs"] if lv["name"] == "swap"]
+    assert len(swap_lvs) == 1
+
+
 def test_efi_partitions_only_for_main_vg() -> None:
     disks = [
         Disk(name="sda", size=1000, rotational=False),
@@ -99,7 +111,8 @@ def test_efi_partitions_only_for_main_vg() -> None:
     assert all(p["type"] == "linux-raid" for p in plan["partitions"]["sdb"])
     assert all(p["type"] == "linux-raid" for p in plan["partitions"]["sdc"])
 
-    def test_prefer_raid6_on_four_disks() -> None:
+
+def test_prefer_raid6_on_four_disks() -> None:
     disks = [
         Disk(name="sda", size=2000, rotational=True),
         Disk(name="sdb", size=2000, rotational=True),


### PR DESCRIPTION
## Summary
- verify storage planner only creates a single swap LV
- adjust filesystem LV test to include HDD for data LV
- fix mis-indented RAID6 test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be58e49818832fb4b4c3477fdeb793