### PR TITLE
Disable dry run by default

### DIFF
--- a/pre_nixos/apply.py
+++ b/pre_nixos/apply.py
@@ -3,7 +3,7 @@
 from typing import Dict, Any, List
 
 
-def apply_plan(plan: Dict[str, Any], dry_run: bool = True) -> List[str]:
+def apply_plan(plan: Dict[str, Any], dry_run: bool = False) -> List[str]:
     """Apply a storage plan.
 
     Parameters:

--- a/pre_nixos/partition.py
+++ b/pre_nixos/partition.py
@@ -11,7 +11,7 @@ def create_partitions(
     *,
     with_efi: bool = True,
     efi_size: str = "512MiB",
-    dry_run: bool = True,
+    dry_run: bool = False,
 ) -> List[str]:
     """Create a GPT with optional EFI and LVM partitions.
 

--- a/pre_nixos/pre_nixos.py
+++ b/pre_nixos/pre_nixos.py
@@ -30,12 +30,17 @@ def main(argv: list[str] | None = None) -> None:
         action="store_true",
         help="Use RAID6 instead of RAID5 for four-disk HDD groups",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Only print commands without executing them",
+    )
     args = parser.parse_args(argv)
 
     if args.partition_boot:
-        partition.create_partitions(args.partition_boot)
+        partition.create_partitions(args.partition_boot, dry_run=args.dry_run)
     for dev in args.partition_lvm:
-        partition.create_partitions(dev, with_efi=False)
+        partition.create_partitions(dev, with_efi=False, dry_run=args.dry_run)
 
     disks = inventory.enumerate_disks()
     plan = planner.plan_storage(
@@ -43,7 +48,7 @@ def main(argv: list[str] | None = None) -> None:
     )
     print(json.dumps(plan, indent=2))
     if not args.plan_only:
-        apply.apply_plan(plan)
+        apply.apply_plan(plan, dry_run=args.dry_run)
 
 
 if __name__ == "__main__":

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -12,7 +12,7 @@ def test_apply_plan_returns_commands() -> None:
         Disk(name="sdc", size=2000, rotational=True),
     ]
     plan = plan_storage("fast", disks)
-    commands = apply_plan(plan)
+    commands = apply_plan(plan, dry_run=True)
     assert any(cmd.startswith("mdadm") for cmd in commands)
     assert any(cmd.startswith("pvcreate") for cmd in commands)
     assert any("vgcreate main" in cmd for cmd in commands)
@@ -35,7 +35,7 @@ def test_apply_plan_handles_swap() -> None:
             {"name": "swap", "vg": "swap", "size": "100%"}
         ],
     }
-    commands = apply_plan(plan)
+    commands = apply_plan(plan, dry_run=True)
     assert "pvcreate /dev/md0" in commands
     assert "vgcreate swap /dev/md0" in commands
     assert "lvcreate -n swap swap -l 100%" in commands

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,8 +12,8 @@ def test_cli_plan_only(monkeypatch, capsys):
     )
     called = []
 
-    def fake_apply(plan):
-        called.append(True)
+    def fake_apply(plan, dry_run=False):
+        called.append(dry_run)
 
     monkeypatch.setattr(pre_nixos.apply, "apply_plan", fake_apply)
     pre_nixos.main(["--plan-only"])
@@ -30,9 +30,9 @@ def test_cli_apply_called(monkeypatch):
     )
     called = []
 
-    def fake_apply(plan):
-        called.append(True)
+    def fake_apply(plan, dry_run=False):
+        called.append(dry_run)
 
     monkeypatch.setattr(pre_nixos.apply, "apply_plan", fake_apply)
     pre_nixos.main([])
-    assert called == [True]
+    assert called == [False]

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -13,7 +13,7 @@ def test_filesystem_commands_for_lvs() -> None:
         Disk(name="sdd", size=1000, rotational=True),
     ]
     plan = plan_storage("fast", disks)
-    commands = apply_plan(plan)
+    commands = apply_plan(plan, dry_run=True)
 
     # mkfs.ext4 uses a 2 KiB bytes-per-inode ratio to avoid inode exhaustion
     # in the Nix store which contains many small files.


### PR DESCRIPTION
## Summary
- Change storage operations to execute by default instead of running a dry run
- Add `--dry-run` CLI option to opt into dry-run behavior
- Update tests for new default behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be605325a4832f85b05aba631a3199