### PR TITLE
Create mount points for non-root LVs

### DIFF
--- a/pre_nixos/apply.py
+++ b/pre_nixos/apply.py
@@ -48,6 +48,8 @@ def apply_plan(plan: Dict[str, Any], dry_run: bool = True) -> List[str]:
         commands.append(f"mkfs.ext4 -i 2048 {lv_path}")
         commands.append(f"e2label {lv_path} {lv['name']}")
         mount_point = "/mnt" if lv["name"] == "root" else f"/mnt/{lv['name']}"
+        if lv["name"] != "root":
+            commands.append(f"mkdir -p {mount_point}")
         commands.append(f"mount -L {lv['name']} {mount_point}")
         if lv["name"] == "swap":
             commands.append(f"mkswap /dev/{lv['vg']}/{lv['name']}")


### PR DESCRIPTION
## Summary
- ensure `apply_plan` makes mount directories before mounting non-root LVs
- add test asserting mount directories are created before mount commands

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be6116c014832fbb665b41a4054ca4