### PR TITLE
Add test ensuring PV creation for RAID arrays

### DIFF
--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -42,3 +42,25 @@ def test_apply_plan_handles_swap() -> None:
     assert commands.index("pvcreate /dev/md0") < commands.index(
         "vgcreate swap /dev/md0"
     )
+
+def test_pv_created_for_each_array() -> None:
+    disks = [
+        Disk(name="sda", size=1000, rotational=False),
+        Disk(name="sdb", size=1000, rotational=False),
+        Disk(name="sdc", size=2000, rotational=True),
+        Disk(name="sdd", size=2000, rotational=True),
+        Disk(name="sde", size=2000, rotational=True),
+        Disk(name="sdf", size=4000, rotational=True),
+        Disk(name="sdg", size=4000, rotational=True),
+        Disk(name="sdh", size=6000, rotational=True),
+        Disk(name="sdi", size=6000, rotational=True),
+        Disk(name="sdj", size=6000, rotational=True),
+        Disk(name="sdk", size=6000, rotational=True),
+    ]
+    plan = plan_storage("fast", disks)
+    commands = apply_plan(plan)
+    # Ensure multiple RAID arrays are present in the plan
+    assert len(plan["arrays"]) >= 4
+    for array in plan["arrays"]:
+        assert f"pvcreate /dev/{array['name']}" in commands
+


### PR DESCRIPTION
## Summary
- extend regression test to cover additional RAID arrays from larger rotating disks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be6172a260832f9a0879017304008c