### PR TITLE
Explicitly size swap LV to double RAM

### DIFF
--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -32,13 +32,13 @@ def test_apply_plan_handles_swap() -> None:
             {"name": "swap", "devices": ["md0"]}
         ],
         "lvs": [
-            {"name": "swap", "vg": "swap", "size": "100%"}
+            {"name": "swap", "vg": "swap", "size": "8G"}
         ],
     }
     commands = apply_plan(plan)
     assert "pvcreate /dev/md0" in commands
     assert "vgcreate swap /dev/md0" in commands
-    assert "lvcreate -n swap swap -l 100%" in commands
+    assert "lvcreate -n swap swap -L 8G" in commands
     assert commands.index("pvcreate /dev/md0") < commands.index(
         "vgcreate swap /dev/md0"
     )

--- a/tests/test_plan_storage.py
+++ b/tests/test_plan_storage.py
@@ -97,6 +97,25 @@ def test_only_one_swap_lv() -> None:
     assert len(swap_lvs) == 1
 
 
+def _ram_mib() -> int:
+    with open("/proc/meminfo") as f:
+        for line in f:
+            if line.startswith("MemTotal:"):
+                return int(line.split()[1]) // 1024
+    return 0
+
+
+def test_swap_size_matches_double_ram() -> None:
+    disks = [
+        Disk(name="sda", size=1000, rotational=False),
+        Disk(name="sdb", size=2000, rotational=True),
+        Disk(name="sdc", size=2000, rotational=True),
+    ]
+    plan = plan_storage("fast", disks)
+    swap_lv = next(lv for lv in plan["lvs"] if lv["name"] == "swap")
+    assert swap_lv["size"] == f"{_ram_mib() * 2}M"
+
+
 def test_efi_partitions_only_for_main_vg() -> None:
     disks = [
         Disk(name="sda", size=1000, rotational=False),


### PR DESCRIPTION
## Summary
- compute system RAM to size swap logical volume at twice memory, avoiding full VG usage
- handle absolute LV sizes in apply step and skip filesystem/mount for swap
- test swap sizing and lvcreate arguments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be60f511e8832f905d6fdcffca21cd