### PR TITLE
Use ram_gb parameter for swap size

### DIFF
--- a/pre_nixos/planner.py
+++ b/pre_nixos/planner.py
@@ -1,20 +1,8 @@
 """Storage planning heuristics."""
 
-from pathlib import Path
 from typing import List, Dict, Any
 
 from .inventory import Disk
-
-
-def _ram_mib(meminfo: Path = Path("/proc/meminfo")) -> int:
-    """Return system RAM in MiB (best effort)."""
-    try:
-        for line in meminfo.read_text().splitlines():
-            if line.startswith("MemTotal:"):
-                return int(line.split()[1]) // 1024
-    except FileNotFoundError:
-        pass
-    return 0
 
 
 def _part_name(device: str, part: int) -> str:
@@ -143,7 +131,7 @@ def plan_storage(
                 {"name": name, "level": arr["level"], "devices": devices, "type": "hdd"}
             )
             plan["vgs"].append({"name": "main", "devices": [name]})
-        swap_size = f"{_ram_mib() * 2}M"
+        swap_size = f"{ram_gb * 2 * 1024}M"
         plan["lvs"].append({"name": "swap", "vg": "main", "size": swap_size})
         plan["lvs"].append({"name": "root", "vg": "main", "size": "100%FREE"})
         return plan
@@ -206,7 +194,7 @@ def plan_storage(
             plan["arrays"].append({"name": name, "level": arr["level"], "devices": devices, "type": "hdd"})
             plan["vgs"].append({"name": vg_name, "devices": [name]})
 
-    swap_size = f"{_ram_mib() * 2}M"
+    swap_size = f"{ram_gb * 2 * 1024}M"
     if any(vg["name"] == "swap" for vg in plan["vgs"]):
         plan["lvs"].append({"name": "swap", "vg": "swap", "size": swap_size})
     if any(vg["name"] == "main" for vg in plan["vgs"]):

--- a/tests/test_plan_storage.py
+++ b/tests/test_plan_storage.py
@@ -120,23 +120,15 @@ def test_only_one_swap_lv() -> None:
     assert len(swap_lvs) == 1
 
 
-def _ram_mib() -> int:
-    with open("/proc/meminfo") as f:
-        for line in f:
-            if line.startswith("MemTotal:"):
-                return int(line.split()[1]) // 1024
-    return 0
-
-
 def test_swap_size_matches_double_ram() -> None:
     disks = [
         Disk(name="sda", size=1000, rotational=False),
         Disk(name="sdb", size=2000, rotational=True),
         Disk(name="sdc", size=2000, rotational=True),
     ]
-    plan = plan_storage("fast", disks)
+    plan = plan_storage("fast", disks, ram_gb=5)
     swap_lv = next(lv for lv in plan["lvs"] if lv["name"] == "swap")
-    assert swap_lv["size"] == f"{_ram_mib() * 2}M"
+    assert swap_lv["size"] == f"{5 * 2 * 1024}M"
 
 
 def test_efi_partitions_only_for_main_vg() -> None:


### PR DESCRIPTION
## Summary
- derive swap LV sizing directly from the `ram_gb` parameter in `plan_storage`
- update tests to validate RAM-based swap sizing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf05e1a2e4832f8be685425148c819