### PR TITLE
Ensure swap created on bulk storage when dedicated swap array absent

### DIFF
--- a/pre_nixos/planner.py
+++ b/pre_nixos/planner.py
@@ -195,11 +195,17 @@ def plan_storage(
             plan["vgs"].append({"name": vg_name, "devices": [name]})
 
     swap_size = f"{ram_gb * 2 * 1024}M"
-    if any(vg["name"] == "swap" for vg in plan["vgs"]):
-        plan["lvs"].append({"name": "swap", "vg": "swap", "size": swap_size})
+    swap_vg = next((vg["name"] for vg in plan["vgs"] if vg["name"] == "swap"), None)
+    if swap_vg is None:
+        swap_vg = next(
+            (vg["name"] for vg in plan["vgs"] if vg["name"].startswith("large")),
+            None,
+        )
+    if swap_vg is not None:
+        plan["lvs"].append({"name": "swap", "vg": swap_vg, "size": swap_size})
     if any(vg["name"] == "main" for vg in plan["vgs"]):
         plan["lvs"].append({"name": "root", "vg": "main", "size": "100%FREE"})
-    if any(vg["name"] == "large" for vg in plan["vgs"]):
+    if any(vg["name"].startswith("large") for vg in plan["vgs"]):
         plan["lvs"].append({"name": "data", "vg": "large", "size": "100%FREE"})
 
     return plan

--- a/tests/test_plan_storage.py
+++ b/tests/test_plan_storage.py
@@ -108,6 +108,21 @@ def test_ssd_only_has_no_swap() -> None:
     assert "swap" not in lv_names
 
 
+def test_swap_lv_falls_back_to_large_vg() -> None:
+    disks = [
+        Disk(name="sda", size=1000, rotational=False),
+        Disk(name="sdb", size=2000, rotational=True),
+        Disk(name="sdc", size=2000, rotational=True),
+        Disk(name="sdd", size=2000, rotational=True),
+    ]
+    plan = plan_storage("fast", disks)
+    vg_names = {vg["name"] for vg in plan["vgs"]}
+    assert "swap" not in vg_names
+    assert "large" in vg_names
+    swap_lv = next(lv for lv in plan["lvs"] if lv["name"] == "swap")
+    assert swap_lv["vg"] == "large"
+
+
 def test_only_one_swap_lv() -> None:
     disks = [
         Disk(name="sda", size=1000, rotational=False),


### PR DESCRIPTION
## Summary
- fall back to allocating swap on the first `large` volume group when no `swap` VG exists
- test that swap LV is provisioned in `large` when no dedicated swap disks are available

## Testing
- `python -m pytest tests/test_plan_storage.py::test_swap_lv_falls_back_to_large_vg -q`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf5c1aa098832fb9dd80d840a08755