### PR TITLE
docs: commit root SSH public key before build

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ this path before building the image (the private key is ignored by git):
 ssh-keygen -t ed25519 -N '' -f pre_nixos/root_ed25519
 ```
 
+After generating the key pair, commit `pre_nixos/root_ed25519.pub` before
+running `nix build`.
+
 Keep `pre_nixos/root_ed25519` secure and uncommitted; its entry in `.gitignore`
 prevents accidental check-in. Use the generated private key to connect once the
 image boots:


### PR DESCRIPTION
## Summary
- mention that the generated `pre_nixos/root_ed25519.pub` should be committed before running `nix build`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0bd39f2f8832f8b7104fda2077005