### PR TITLE
Restrict root key ignore pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 __pycache__/
 *.pyc
-
-pre_nixos/root_ed25519*
+pre_nixos/root_ed25519


### PR DESCRIPTION
## Summary
- narrow `.gitignore` entry to only ignore `pre_nixos/root_ed25519`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0bd39e6a4832f8b666f57b357ad92