### PR TITLE
fix: include setuptools in build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 pre_nixos/root_ed25519
+pre_nixos/root_ed25519.pub

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
           version = "0.1.0";
           src = ./.;
           pyproject = true;
+          nativeBuildInputs = with pkgs.python3Packages; [ setuptools wheel ];
           propagatedBuildInputs = with pkgs; [ gptfdisk mdadm lvm2 ethtool ];
           postPatch = ''
             cp ${rootPub} pre_nixos/root_ed25519.pub


### PR DESCRIPTION
## Summary
- ensure Python build uses setuptools and wheel

## Testing
- `python3 -m pytest`
- `nix --extra-experimental-features 'nix-command flakes' build` *(fails: getting status of '/nix/store/lixi0aksmg1qn68xss34rzdvbyqqz1wz-source/pre_nixos/root_ed25519.pub': No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c0bf7d06a4832fb368ffefaecd3cc2