### PR TITLE
Fix Python packaging by excluding modules directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ authors = [{name = "Unknown"}]
 readme = "README.md"
 requires-python = ">=3.10"
 
+[tool.setuptools]
+packages = ["pre_nixos"]
+
 [project.scripts]
 pre-nixos = "pre_nixos.pre_nixos:main"
 


### PR DESCRIPTION
## Summary
- configure setuptools to package only `pre_nixos`

## Testing
- `pytest -q`
- `python -m build`
- `nix build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c715c7a8832f851bb4ff488b1559