### PR TITLE
Add bootImage alias for NixOS installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,5 +76,11 @@ Expose the tool on a system via the flake's NixOS module:
 Build a bootable ISO that runs `pre-nixos` automatically:
 
 ```bash
+nix build .#bootImage
+```
+
+The longer attribute path remains available if needed:
+
+```bash
 nix build .#nixosConfigurations.pre-installer.config.system.build.isoImage
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -25,8 +25,12 @@
           '';
         };
       in {
-        packages.default = pre-nixos;
-        packages.pre-nixos = pre-nixos;
+        packages = {
+          default = pre-nixos;
+          pre-nixos = pre-nixos;
+        } // pkgs.lib.optionalAttrs (system == "x86_64-linux") {
+          bootImage = self.nixosConfigurations.pre-installer.config.system.build.isoImage;
+        };
         devShells.default = pkgs.mkShell {
           buildInputs = [ pkgs.python3 pkgs.python3Packages.pytest ];
         };


### PR DESCRIPTION
## Summary
- expose bootImage flake output for the pre-installer ISO
- document new `nix build .#bootImage` shortcut

## Testing
- `pytest`
- `nix --extra-experimental-features 'nix-command flakes' flake show`

------
https://chatgpt.com/codex/tasks/task_e_68c0d042da98832f85bca806d7ff619c