### PR TITLE
Make boot image default and remove sample SSH key

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,16 @@ pytest
 
 ## Nix flake
 
-Build the CLI as a Nix package:
+Build a bootable ISO that runs `pre-nixos` automatically:
 
 ```bash
 nix build
+```
+
+Build the CLI as a Nix package:
+
+```bash
+nix build .#pre-nixos
 ```
 
 Enter a development shell with dependencies:
@@ -71,16 +77,9 @@ Expose the tool on a system via the flake's NixOS module:
 }
 ```
 
-## ISO image
-
-Build a bootable ISO that runs `pre-nixos` automatically:
+The explicit attribute paths remain available if needed:
 
 ```bash
 nix build .#bootImage
-```
-
-The longer attribute path remains available if needed:
-
-```bash
 nix build .#nixosConfigurations.pre-installer.config.system.build.isoImage
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This project contains tools to prepare bare-metal machines for a NixOS installation. It discovers hardware, plans a storage layout, configures the active network interface for DHCP (renaming it to `lan`), and can apply that plan. When multiple disk groups qualify for the same tier, only the largest is mounted as `main` or `large`; smaller groups receive suffixed VG names and are left unmounted for manual use after installation.
 
-> **Important:** Before building the boot image, place your SSH public key at `pre_nixos/root_ed25519.pub`. The build fails if the file is missing.
+> **Note:** To enable SSH access on the boot image, place your SSH public key at
+> `pre_nixos/root_ed25519.pub` before building. If the file is absent, the image
+> falls back to the NixOS default of console-only access.
 
 ## Usage
 
@@ -27,7 +29,7 @@ ssh-keygen -t ed25519 -N '' -f pre_nixos/root_ed25519
 ```
 
 After generating the key pair, commit `pre_nixos/root_ed25519.pub` before
-running `nix build`.
+running `nix build` so that the key is embedded in the image.
 
 Keep `pre_nixos/root_ed25519` secure and uncommitted; its entry in `.gitignore`
 prevents accidental check-in. Use the generated private key to connect once the

--- a/flake.nix
+++ b/flake.nix
@@ -25,12 +25,15 @@
           '';
         };
       in {
-        packages = {
-          default = pre-nixos;
-          pre-nixos = pre-nixos;
-        } // pkgs.lib.optionalAttrs (system == "x86_64-linux") {
-          bootImage = self.nixosConfigurations.pre-installer.config.system.build.isoImage;
-        };
+        packages =
+          if system == "x86_64-linux" then {
+            default = self.nixosConfigurations.pre-installer.config.system.build.isoImage;
+            bootImage = self.nixosConfigurations.pre-installer.config.system.build.isoImage;
+            pre-nixos = pre-nixos;
+          } else {
+            default = pre-nixos;
+            pre-nixos = pre-nixos;
+          };
         devShells.default = pkgs.mkShell {
           buildInputs = [ pkgs.python3 pkgs.python3Packages.pytest ];
         };

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,12 @@
 
   outputs = { self, nixpkgs, flake-utils, ... }:
     let
-      rootPub = builtins.path { path = ./pre_nixos/root_ed25519.pub; };
+      rootPubPath = "pre_nixos/root_ed25519.pub";
+      rootPub =
+        if builtins.pathExists rootPubPath then
+          builtins.path { path = ./${rootPubPath}; }
+        else
+          null;
     in
     flake-utils.lib.eachDefaultSystem (system:
       let
@@ -20,7 +25,7 @@
           pyproject = true;
           nativeBuildInputs = with pkgs.python3Packages; [ setuptools wheel ];
           propagatedBuildInputs = with pkgs; [ gptfdisk mdadm lvm2 ethtool ];
-          postPatch = ''
+          postPatch = pkgs.lib.optionalString (rootPub != null) ''
             cp ${rootPub} pre_nixos/root_ed25519.pub
           '';
         };

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -62,6 +62,24 @@ def test_configure_lan_writes_network_file(tmp_path):
     assert "PasswordAuthentication no" in ssh_conf.read_text()
 
 
+def test_configure_lan_skips_without_key(tmp_path):
+    netdir = tmp_path / "sys/class/net"
+    netdir.mkdir(parents=True)
+    iface = netdir / "eth0"
+    iface.mkdir()
+    (iface / "device").mkdir()
+    (iface / "carrier").write_text("1")
+
+    network_dir = tmp_path / "etc/systemd/network"
+    ssh_dir = tmp_path / "etc/ssh"
+    root_home = tmp_path / "root"
+
+    result = configure_lan(netdir, network_dir, ssh_dir, root_home=root_home)
+    assert result is None
+    assert not (network_dir / "20-lan.network").exists()
+    assert not (root_home / ".ssh/authorized_keys").exists()
+
+
 def test_secure_ssh_replaces_symlink_and_filters_insecure_directives(tmp_path):
     ssh_dir = tmp_path / "etc/ssh"
     ssh_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- remove committed root SSH public key
- make bootable ISO the flake's default package
- document new default build target and CLI build instructions

## Testing
- `pytest`
- `curl -L https://nixos.org/nix/install -o /tmp/install-nix.sh && sh /tmp/install-nix.sh --no-daemon` *(fails: CONNECT tunnel failed, response 403)*
- `nix build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0dd54841c832f9165411dd57457a1