### PR TITLE
fix: use absolute path for root public key

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,10 +8,10 @@
 
   outputs = { self, nixpkgs, flake-utils, ... }:
     let
-      rootPubPath = "pre_nixos/root_ed25519.pub";
+      rootPubPath = "${builtins.toString ./.}/pre_nixos/root_ed25519.pub";
       rootPub =
         if builtins.pathExists rootPubPath then
-          builtins.path { path = ./${rootPubPath}; }
+          builtins.path { path = builtins.toPath rootPubPath; }
         else
           null;
     in


### PR DESCRIPTION
## Summary
- use an absolute path for `root_ed25519.pub` when building the boot image

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c21595889c832f8c19ef56a8d94cd6