### PR TITLE
Start sshd after hardening instead of enabling

### DIFF
--- a/automated-pre-nixos-design.md
+++ b/automated-pre-nixos-design.md
@@ -123,7 +123,7 @@ Provision bare-metal servers to a **known, repeatable disk + network baseline** 
 
 ### 7.8 SSH exposure
 - Install built-in `authorized_keys` for root and harden `sshd_config` to disable password logins while preserving the root password for console access.
-- The OpenSSH service remains disabled during boot and is enabled/started only after this hardening step.
+- The OpenSSH service remains disabled during boot and is started only after this hardening step.
 - Announce IP + fingerprint via log fan-out.
 
 ### 7.9 Outputs
@@ -144,7 +144,7 @@ Provision bare-metal servers to a **known, repeatable disk + network baseline** 
    - Establish **non-blocking log fan-out**: log to journald, append to `/var/log/pre-nixos/actions.log`, send to `dmesg`, and write to the kernel console (e.g., `printf ... > /dev/console` with timeouts).
    - If no serial console is present/connected, skip console writes silently; never fail the step on serial errors.
    - Mount boot media read-only; import config file if present.
-2. **Network stage:** probe carriers; choose NIC; write persistent rename → `lan`; start DHCP; if a root key is present, run `secure_ssh` to harden configuration and enable `sshd`; otherwise leave `sshd` disabled; print IP via logging fan-out (serial best-effort/time-bounded).
+2. **Network stage:** probe carriers; choose NIC; write persistent rename → `lan`; start DHCP; if a root key is present, run `secure_ssh` to harden configuration and start `sshd`; otherwise leave `sshd` disabled; print IP via logging fan-out (serial best-effort/time-bounded).
 3. **Discovery:** enumerate disks; compute candidate RAID groups, and write a plan without modifying any disks.
 4. **Apply plan (manual):**
    - After operator review (e.g., via `pre-nixos-tui`, which shows the current IP or a status message), confirm boot target (SSD/NVMe) and wipe signatures (configurable safety).

--- a/pre_nixos/network.py
+++ b/pre_nixos/network.py
@@ -96,9 +96,7 @@ def get_ip_address(iface: str = "lan") -> Optional[str]:
     return None
 
 
-def get_lan_status(
-    authorized_key: Optional[Path] = None, iface: str = "lan"
-) -> str:
+def get_lan_status(authorized_key: Optional[Path] = None, iface: str = "lan") -> str:
     """Return the LAN IP address or diagnostic message for the TUI.
 
     If the embedded public SSH key is missing, ``secure_ssh`` never ran and
@@ -135,7 +133,7 @@ def secure_ssh(
 
     The main ``sshd_config`` file is updated to prohibit password logins,
     an authorized key is installed for the root account, and the SSH service
-    is enabled and reloaded. The root password itself remains usable for
+    is started and reloaded. The root password itself remains usable for
     console logins.
     """
 
@@ -181,7 +179,7 @@ def secure_ssh(
     os.chmod(root_ssh, 0o700)
     os.chmod(auth_path, 0o600)
 
-    _run(["systemctl", "enable", "--now", ssh_service])
+    _run(["systemctl", "start", ssh_service])
     _run(["systemctl", "reload", ssh_service])
     return conf_path
 


### PR DESCRIPTION
## Summary
- start sshd with `systemctl start` after `secure_ssh` hardens the configuration
- clarify design that sshd is started, not enabled, after hardening

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2c0f5f7fc832fa2d9143ab56b2a56