### PR TITLE
Add load/save options to storage-plan TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ embedded SSH key is missing or no address was assigned:
 ```bash
 pre-nixos-tui
 ```
+Within the interface press `S` to save the current plan to a JSON file or `L`
+to load an existing plan.
 
 ## SSH access
 

--- a/pre_nixos/planner.py
+++ b/pre_nixos/planner.py
@@ -170,9 +170,10 @@ def plan_storage(
                     parts.append({"name": _part_name(d.name, idx), "type": "efi"})
                     idx += 1
                 ptype = "linux-raid" if raid else "lvm"
-                parts.append({"name": _part_name(d.name, idx), "type": ptype})
+                part_name = _part_name(d.name, idx)
+                parts.append({"name": part_name, "type": ptype})
                 plan["partitions"][d.name] = parts
-                device_sizes[part_name] = _to_bytes(d.size)     
+                device_sizes[part_name] = _to_bytes(d.size)
             # last partition in the list is always the data one
             devices.append(plan["partitions"][d.name][-1]["name"])
         return devices

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,3 +1,4 @@
+import json
 import pre_nixos.tui as tui
 
 
@@ -49,3 +50,32 @@ def test_draw_plan_displays_messages(monkeypatch):
     monkeypatch.setattr(tui.network, "get_lan_status", lambda: "missing SSH public key")
     tui._draw_plan(win, {"a": 1})
     assert "missing SSH public key" in win.lines[0]
+
+
+def test_save_and_load_plan(tmp_path, monkeypatch):
+    class FakeWin:
+        def __init__(self, inputs):
+            self._inputs = inputs
+
+        def clear(self):
+            pass
+
+        def addstr(self, *args):
+            pass
+
+        def getstr(self):
+            return self._inputs.pop(0)
+
+    monkeypatch.setattr(tui.curses, "echo", lambda: None)
+    monkeypatch.setattr(tui.curses, "noecho", lambda: None)
+
+    plan = {"a": 1}
+    path = tmp_path / "plan.json"
+
+    win = FakeWin([str(path).encode()])
+    tui._save_plan(win, plan)
+    assert json.loads(path.read_text()) == plan
+
+    win = FakeWin([str(path).encode()])
+    loaded = tui._load_plan(win, {"old": 0})
+    assert loaded == plan


### PR DESCRIPTION
## Summary
- fix undefined variable when recording partitions
- allow saving and loading storage plans from the TUI
- document new save/load keys and add tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2c697f408832f92e312b643abfb83