### PR TITLE
Refactor storage detection logic into module and surface provisioning status

### DIFF
--- a/modules/pre-nixos.nix
+++ b/modules/pre-nixos.nix
@@ -1,11 +1,19 @@
 { config, lib, pkgs, ... }:
 let
   cfg = config.services.pre-nixos;
+  # ``pre-nixos`` only executes disk and network commands when PRE_NIXOS_EXEC is
+  # set.  Propagate it to login shells for the TUI and to the systemd unit so the
+  # boot-time invocation can configure networking.
+  preNixosExecEnv = { PRE_NIXOS_EXEC = "1"; };
+  preNixosLoginNotice = builtins.readFile ./pre-nixos/login-notice.sh;
+  preNixosServiceScript = import ./pre-nixos/service-script.nix { inherit pkgs; };
 in {
   options.services.pre-nixos.enable = lib.mkEnableOption "run pre-nixos planning tool";
 
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [ pkgs.pre-nixos ];
+    environment.sessionVariables = preNixosExecEnv;
+    environment.interactiveShellInit = preNixosLoginNotice;
     boot.kernelParams = [ "console=ttyS0,115200n8" "console=tty0" ];
     boot.loader.grub.extraConfig = ''
       serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1
@@ -16,10 +24,8 @@ in {
       description = "Pre-NixOS setup";
       wantedBy = [ "multi-user.target" ];
       serviceConfig.Type = "oneshot";
-      environment = { PRE_NIXOS_EXEC = "1"; };
-      script = ''
-        ${pkgs.pre-nixos}/bin/pre-nixos --plan-only
-      '';
+      environment = preNixosExecEnv;
+      script = preNixosServiceScript;
     };
 
     # Keep OpenSSH disabled until secure_ssh hardens the configuration.

--- a/modules/pre-nixos/login-notice.sh
+++ b/modules/pre-nixos/login-notice.sh
@@ -1,0 +1,49 @@
+# shellcheck shell=sh
+status_file=/run/pre-nixos/storage-status
+if [ -r "$status_file" ]; then
+  state=""
+  detail=""
+  while IFS='=' read -r key value; do
+    case "$key" in
+      STATE) state=$value ;;
+      DETAIL) detail=$value ;;
+    esac
+  done < "$status_file"
+  case "$state" in
+    applied)
+      if [ "$detail" = "auto-applied" ]; then
+        printf '%s\n' "pre-nixos: Storage provisioning completed automatically."
+      fi
+      ;;
+    plan-only)
+      if [ "$detail" = "existing-storage" ]; then
+        printf '%s\n' "pre-nixos: Existing storage detected; provisioning ran in plan-only mode."
+        printf '%s\n' "             Review and apply the plan with 'pre-nixos' or 'pre-nixos-tui'."
+      elif [ "$detail" = "detection-error" ]; then
+        printf '%s\n' "pre-nixos: Storage detection encountered an error; provisioning ran in plan-only mode."
+        printf '%s\n' "             Check 'journalctl -u pre-nixos' for details before continuing."
+      else
+        printf '%s\n' "pre-nixos: Provisioning ran in plan-only mode. Review before applying."
+      fi
+      ;;
+    failed)
+      case "$detail" in
+        existing-storage)
+          printf '%s\n' "pre-nixos: Provisioning failed while running in plan-only mode after detecting existing storage."
+          ;;
+        detection-error)
+          printf '%s\n' "pre-nixos: Provisioning failed after a detection error forced plan-only mode."
+          ;;
+        *)
+          printf '%s\n' "pre-nixos: Provisioning failed."
+          ;;
+      esac
+      printf '%s\n' "             Inspect 'journalctl -u pre-nixos' for failure details."
+      ;;
+    "")
+      ;;
+    *)
+      printf '%s\n' "pre-nixos: Provisioning status is '$state' ($detail)."
+      ;;
+  esac
+fi

--- a/modules/pre-nixos/service-script.nix
+++ b/modules/pre-nixos/service-script.nix
@@ -1,0 +1,42 @@
+{ pkgs }:
+let
+  detectStorageCmd = "${pkgs.pre-nixos}/bin/pre-nixos-detect-storage";
+  preNixosCmd = "${pkgs.pre-nixos}/bin/pre-nixos";
+in ''
+  set -euo pipefail
+
+  status_dir=/run/pre-nixos
+  status_file=$status_dir/storage-status
+  mkdir -p "$status_dir"
+
+  plan_flag=""
+  status_state="applied"
+  status_detail="auto-applied"
+
+  if ${detectStorageCmd}; then
+    plan_flag="--plan-only"
+    status_state="plan-only"
+    status_detail="existing-storage"
+  else
+    status=$?
+    if [ "$status" -ne 1 ]; then
+      echo "pre-nixos: storage detection failed (exit $status), defaulting to plan-only" >&2
+      plan_flag="--plan-only"
+      status_state="plan-only"
+      status_detail="detection-error"
+    fi
+  fi
+
+  if ${preNixosCmd} $plan_flag; then
+    cat > "$status_file" <<EOF_STATUS
+STATE=$status_state
+DETAIL=$status_detail
+EOF_STATUS
+  else
+    cat > "$status_file" <<EOF_STATUS
+STATE=failed
+DETAIL=$status_detail
+EOF_STATUS
+    exit 1
+  fi
+''

--- a/pre_nixos/storage_detection.py
+++ b/pre_nixos/storage_detection.py
@@ -1,0 +1,178 @@
+"""Detection helpers for existing storage signatures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+import subprocess
+import sys
+from typing import Callable, Iterable, Optional, Sequence
+
+__all__ = [
+    "CommandOutput",
+    "DetectionEnvironment",
+    "resolve_boot_disk",
+    "has_existing_storage",
+    "main",
+]
+
+
+@dataclass
+class CommandOutput:
+    """Minimal command result container for dependency injection."""
+
+    stdout: str
+    returncode: int = 0
+
+
+class DetectionEnvironment:
+    """Encapsulate external interactions for storage detection."""
+
+    def __init__(
+        self,
+        *,
+        run: Callable[[Sequence[str]], CommandOutput] | None = None,
+        path_exists: Callable[[str], bool] | None = None,
+        realpath: Callable[[str], str] | None = None,
+        read_cmdline: Callable[[], Sequence[str]] | None = None,
+    ) -> None:
+        self.run = run or self._default_run
+        self.path_exists = path_exists or os.path.exists
+        self.realpath = realpath or os.path.realpath
+        self.read_cmdline = read_cmdline or self._default_read_cmdline
+
+    @staticmethod
+    def _default_run(cmd: Sequence[str]) -> CommandOutput:
+        completed = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return CommandOutput(stdout=completed.stdout, returncode=completed.returncode)
+
+    @staticmethod
+    def _default_read_cmdline() -> Sequence[str]:
+        try:
+            with open("/proc/cmdline", "r", encoding="utf-8") as fp:
+                data = fp.read()
+        except OSError:
+            return []
+        return data.split()
+
+
+_BOOT_ARG_PREFIXES = {
+    "boot=LABEL=": "/dev/disk/by-label/",
+    "boot=UUID=": "/dev/disk/by-uuid/",
+}
+
+
+_IGNORED_DEVICE_PREFIXES = (
+    "/dev/loop",
+    "/dev/zram",
+    "/dev/ram",
+    "/dev/dm",
+    "/dev/md",
+    "/dev/sr",
+)
+
+
+def _run_command(
+    env: DetectionEnvironment, cmd: Sequence[str], *, ignore_errors: bool = False
+) -> str:
+    result = env.run(cmd)
+    if result.returncode != 0:
+        if ignore_errors:
+            return ""
+        raise RuntimeError(
+            f"command {' '.join(cmd)} exited with status {result.returncode}"
+        )
+    return result.stdout
+
+
+def resolve_boot_disk(env: DetectionEnvironment | None = None) -> Optional[str]:
+    """Determine the disk that hosts the boot media, if possible."""
+
+    env = env or DetectionEnvironment()
+
+    for arg in env.read_cmdline():
+        for prefix, base in _BOOT_ARG_PREFIXES.items():
+            if not arg.startswith(prefix):
+                continue
+            candidate = base + arg[len(prefix) :]
+            if not env.path_exists(candidate):
+                continue
+            boot_device = env.realpath(candidate)
+            parent = _run_command(
+                env, ["lsblk", "-npo", "PKNAME", boot_device], ignore_errors=True
+            ).strip()
+            if parent:
+                return env.realpath(f"/dev/{parent}")
+            return boot_device
+
+    boot_source = _run_command(
+        env, ["findmnt", "-n", "-o", "SOURCE", "/iso"], ignore_errors=True
+    ).strip()
+    if boot_source and env.path_exists(boot_source):
+        parent = _run_command(
+            env, ["lsblk", "-npo", "PKNAME", boot_source], ignore_errors=True
+        ).strip()
+        if parent:
+            return env.realpath(f"/dev/{parent}")
+        return env.realpath(boot_source)
+
+    return None
+
+
+def _iter_lsblk_rows(output: str) -> Iterable[tuple[str, str]]:
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split()
+        if len(parts) != 2:
+            continue
+        yield parts[0], parts[1]
+
+
+def has_existing_storage(
+    env: DetectionEnvironment | None = None,
+    *,
+    boot_disk: Optional[str] = None,
+) -> bool:
+    """Return True when non-boot disks contain partitions or signatures."""
+
+    env = env or DetectionEnvironment()
+    listing = _run_command(env, ["lsblk", "-dnpo", "NAME,TYPE"])
+    for device, dev_type in _iter_lsblk_rows(listing):
+        if dev_type != "disk":
+            continue
+        if device.startswith(_IGNORED_DEVICE_PREFIXES):
+            continue
+        resolved = env.realpath(device)
+        if boot_disk and resolved == boot_disk:
+            continue
+        type_listing = _run_command(env, ["lsblk", "-rno", "TYPE", device])
+        type_lines = [line for line in type_listing.splitlines() if line.strip()]
+        if len(type_lines) > 1:
+            return True
+        wipefs_output = _run_command(env, ["wipefs", "-n", device])
+        if wipefs_output.strip():
+            return True
+    return False
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:  # pragma: no cover - thin wrapper
+    del argv
+    env = DetectionEnvironment()
+    try:
+        boot_disk = resolve_boot_disk(env)
+        if has_existing_storage(env, boot_disk=boot_disk):
+            return 0
+        return 1
+    except Exception as exc:
+        print(f"pre-nixos-detect-storage: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ packages = ["pre_nixos"]
 
 [project.scripts]
 pre-nixos = "pre_nixos.pre_nixos:main"
+pre-nixos-detect-storage = "pre_nixos.storage_detection:main"
 pre-nixos-tui = "pre_nixos.tui:run"
 
 [build-system]

--- a/tests/test_storage_detection.py
+++ b/tests/test_storage_detection.py
@@ -1,0 +1,97 @@
+"""Tests for detecting existing storage signatures."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Sequence, Tuple
+
+from pre_nixos.storage_detection import (
+    CommandOutput,
+    DetectionEnvironment,
+    has_existing_storage,
+    resolve_boot_disk,
+)
+
+
+CommandMap = Dict[Tuple[str, ...], CommandOutput]
+
+
+def make_env(
+    commands: CommandMap,
+    *,
+    path_exists: Callable[[str], bool] | None = None,
+    realpath: Callable[[str], str] | None = None,
+    read_cmdline: Callable[[], Sequence[str]] | None = None,
+) -> DetectionEnvironment:
+    def run(cmd: Sequence[str]) -> CommandOutput:
+        key = tuple(cmd)
+        if key not in commands:
+            raise AssertionError(f"unexpected command invocation: {cmd}")
+        return commands[key]
+
+    return DetectionEnvironment(
+        run=run,
+        path_exists=path_exists or (lambda _path: False),
+        realpath=realpath or (lambda path: path),
+        read_cmdline=read_cmdline or (lambda: []),
+    )
+
+
+def test_detects_partitions_as_existing() -> None:
+    commands = {
+        ("lsblk", "-dnpo", "NAME,TYPE"): CommandOutput(
+            stdout="/dev/sdb disk\n", returncode=0
+        ),
+        ("lsblk", "-rno", "TYPE", "/dev/sdb"): CommandOutput(
+            stdout="disk\npart\n", returncode=0
+        ),
+        ("wipefs", "-n", "/dev/sdb"): CommandOutput(stdout="", returncode=0),
+    }
+    env = make_env(commands)
+    assert has_existing_storage(env, boot_disk=None)
+
+
+def test_detects_wipefs_signature_without_partitions() -> None:
+    commands = {
+        ("lsblk", "-dnpo", "NAME,TYPE"): CommandOutput(
+            stdout="/dev/sdc disk\n", returncode=0
+        ),
+        ("lsblk", "-rno", "TYPE", "/dev/sdc"): CommandOutput(stdout="disk\n", returncode=0),
+        (
+            "wipefs",
+            "-n",
+            "/dev/sdc",
+        ): CommandOutput(stdout="0x1234\tfilesystem", returncode=0),
+    }
+    env = make_env(commands)
+    assert has_existing_storage(env, boot_disk=None)
+
+
+def test_only_boot_disk_is_ignored() -> None:
+    commands = {
+        ("lsblk", "-npo", "PKNAME", "/dev/sda1"): CommandOutput(
+            stdout="sda\n", returncode=0
+        ),
+        ("findmnt", "-n", "-o", "SOURCE", "/iso"): CommandOutput(stdout="", returncode=1),
+        ("lsblk", "-dnpo", "NAME,TYPE"): CommandOutput(
+            stdout="/dev/sda disk\n", returncode=0
+        ),
+    }
+    known_paths = {"/dev/disk/by-label/BOOT", "/dev/sda1", "/dev/sda"}
+
+    def path_exists(path: str) -> bool:
+        return path in known_paths
+
+    def realpath(path: str) -> str:
+        if path == "/dev/disk/by-label/BOOT":
+            return "/dev/sda1"
+        return path
+
+    env = make_env(
+        commands,
+        path_exists=path_exists,
+        realpath=realpath,
+        read_cmdline=lambda: ["boot=LABEL=BOOT"],
+    )
+    boot_disk = resolve_boot_disk(env)
+    assert boot_disk == "/dev/sda"
+    assert not has_existing_storage(env, boot_disk=boot_disk)


### PR DESCRIPTION
## Summary
- move existing storage detection into a dedicated `pre_nixos.storage_detection` helper with a CLI entry point
- update the pre-nixos systemd service to rely on the helper and default to plan-only when detection fails
- cover the helper with unit tests for boot disk resolution and signature detection
- persist the provisioning outcome for login shells so users immediately see whether storage was applied or left in plan-only mode
- split the login notice and systemd service scripts into dedicated files to keep `pre-nixos.nix` concise

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf012045a4832f8200b51ce519d7cd