### PR TITLE
Render storage plan in adaptive TUI layout

### DIFF
--- a/automated-pre-nixos-design-changelog.md
+++ b/automated-pre-nixos-design-changelog.md
@@ -64,3 +64,23 @@
 ### v0.14 — 2025-09-11
 - TUI now reports when the embedded SSH key is missing or no IP address is
   assigned.
+
+### v0.15 — 2025-09-11
+- Documented a pictorial TUI layout with four-column disk→array→VG→LV flow.
+- Added design for zoomable overview/detailed modes driven by terminal size.
+- Captured requirement to toggle between existing storage state and planned
+  layout, highlighting differences directly in the UI.
+
+### v0.16 — 2025-09-11
+- Refined the TUI density handling to probe the layout off-screen and choose the
+  richest profile that fits the current terminal instead of relying on a static
+  80×24 cutoff.
+- Clarified that manual zoom is anchored on the focused branch so comparisons
+  keep the same subtree centred when switching views.
+
+### v0.17 — 2025-09-11
+- Published detailed ASCII mock frames under `docs/tui-mockups/` covering mixed
+  SSD/HDD plans, the auto-scaled 80×24 minimal profile, and side-by-side
+  existing-versus-planned comparisons.
+- Linked the main design doc to those mocks so implementers have copy-ready
+  targets for rendering behaviour.

--- a/docs/tui-mockups/README.md
+++ b/docs/tui-mockups/README.md
@@ -1,0 +1,9 @@
+# TUI Mock Reference Frames
+
+This folder collects ASCII snapshots that guided the adaptive storage-plan renderer:
+
+- `detailed-mixed-tier.md` — fully expanded view on a large terminal, demonstrating SSD/HDD tiers, mismatch badges, and focus pins.
+- `minimal-overview-80x24.md` — minimal density layout captured after probing an 80×24 terminal.
+- `existing-vs-planned.md` — paired frames comparing live storage against the computed plan while keeping the same focus anchor.
+
+Implementers can copy individual frames into unit tests or manual notes when validating the renderer.

--- a/docs/tui-mockups/detailed-mixed-tier.md
+++ b/docs/tui-mockups/detailed-mixed-tier.md
@@ -1,0 +1,26 @@
+# TUI Mock — Detailed Planned View (Mixed SSD + HDD Tiers)
+
+This mock illustrates the **detailed** density profile on an 110×34 terminal. All columns are fully expanded and the focus cursor rests on the `VG large` row so proportional zooming highlights that subtree without collapsing sibling content.
+
+```
+IP: 198.51.100.42 (lan)    View: Planned (detailed)           Focus: VG large          Legend: ■ SSD  ● HDD  ☐ EFI  ≡ RAID  ✱ mismatch
+
+Disk nvme0n1  ⟟ ─[☐ EFI]─[■ nvme0n1p2]─────────────┐
+                                                ├── md0 ≡ RAID1 (SSD) ── VG main ── root 40G (ext4)
+Disk nvme1n1  ⟟ ───────────────[■ nvme1n1p1]───────┘                         └─ nix 120G (ext4, dense)
+                                                                             └─ var 30G (ext4)
+Disk nvme2n1  ⟟ ───────────────[■ (unused)]             (spare SSD bucket → VG main-1, unmounted)
+
+Disk sda      ◎ ─[● sda1 swap-mirror]──────┐
+                                          ├── md1 ≡ RAID1 (HDD mirror) ── VG swap ── swap 64G (mkswap)
+Disk sdb      ◎ ─[● sdb1 swap-mirror]──────┘
+             ◎ ─[● sdb2 data]──────────────┐
+Disk sdc      ◎ ─[● sdc1 data]─────────────┴── md2 ≡ RAID6 (HDD) ── ▶ VG large ── data 6T (ext4)
+Disk sdd      ◎ ─[● sdd1 data]──────────────┘                         └─ backups 2T (ext4) ✱ ← missing on disk
+Disk sde      ◎ ─[● sde1 data]───────────────┐
+Disk sdf      ◎ ─[● sdf1 data]───────────────┘
+```
+
+* **Focus indicator (`▶`)** forces the `VG large` branch to stay expanded even if the renderer later chooses the compact profile for siblings.
+* **Mismatch badge (`✱ ← missing on disk`)** demonstrates how planned-only LVs are called out without relying on vertical separators.
+* SSD spares show as annotations so operators know why devices are idle yet still part of the plan.

--- a/docs/tui-mockups/existing-vs-planned.md
+++ b/docs/tui-mockups/existing-vs-planned.md
@@ -1,0 +1,33 @@
+# TUI Mock — Existing vs. Planned Toggle with Mismatch Signals
+
+The following pair of frames demonstrates how the UI reuses the same focus anchor (`LV data`) while switching between the live inventory and the computed plan. Both fits use the **compact** profile on a 100×28 terminal.
+
+## Frame A — Existing layout (View: Existing)
+```
+IP: 192.0.2.45 (lan)  View: Existing (compact)  Focus: LV data         Legend: ■ SSD  ● HDD  ☐ EFI  ≡ RAID  ░ dim=not in plan
+
+Disk nvme0n1  ⟟ ─[☐ EFI]─[■ nvme0n1p2]──────────┐
+                                              ├── md0 ≡ RAID1 (SSD) ── VG main ── root 35G
+Disk nvme1n1  ⟟ ───────────────[■ nvme1n1p1]────┘                         └─ nix 90G (fragmented)
+
+Disk sda      ◎ ─[● sda1 data]──────────────┐
+Disk sdb      ◎ ─[● sdb1 data]──────────────┴── md2 ≡ RAID5 (HDD) ── VG large ── ▶ data 4T (ext4, 68% used)
+                                                                       ░ └─ oldlogs 500G (orphan)
+```
+
+## Frame B — Planned layout (View: Planned)
+```
+IP: 192.0.2.45 (lan)  View: Planned (compact)   Focus: LV data         Legend: ■ SSD  ● HDD  ☐ EFI  ≡ RAID  ✱ mismatch
+
+Disk nvme0n1  ⟟ ─[☐ EFI]─[■ nvme0n1p2]──────────┐
+                                              ├── md0 ≡ RAID1 (SSD) ── VG main ── root 40G (ext4)
+Disk nvme1n1  ⟟ ───────────────[■ nvme1n1p1]────┘                         └─ nix 120G (ext4, dense)
+
+Disk sda      ◎ ─[● sda1 data]──────────────┐
+Disk sdb      ◎ ─[● sdb1 data]──────────────┴── md2 ≡ RAID6 (HDD) ── VG large ── ▶ data 3T (ext4)
+                                                                       └─ backups 1T (ext4) ✱ ← level differs (R5→R6)
+```
+
+* Dimming (`░`) in the existing view marks components the plan intends to remove.
+* Planned-only or changed resources render a right-column badge with an arrow summarising the drift cause.
+* Because the focus stays on `LV data`, operators can immediately compare sizes and RAID levels without re-navigating.

--- a/docs/tui-mockups/minimal-overview-80x24.md
+++ b/docs/tui-mockups/minimal-overview-80x24.md
@@ -1,0 +1,18 @@
+# TUI Mock — Minimal Auto-Scaled View (80×24 Terminal)
+
+This sketch shows the renderer after probing an 80×24 terminal and falling back to the **minimal** profile. Non-focused branches collapse into counts and abbreviated labels so the canvas fits within the constrained viewport.
+
+```
+IP: 203.0.113.17 (lan)  View: Planned (minimal)  Focus: Disk nvme0n1  Legend: ■ SSD  ● HDD  ☐ EFI  ≡ RAID
+
+▶ Disk nvme0n1  ⟟  ESP+main (2 parts)   ⇒  md0 ≡ R1 (SSD)   ⇒  VG main (3 LVs)
+  Disk nvme1n1  ⟟  member only
+  Disk nvme2n1  ⟟  spare bucket (main-1)
+
+  HDD bucket A (6 disks)   ⇒  md2 ≡ R6   ⇒  VG large (2 LVs)
+  HDD bucket B (2 disks)   ⇒  swap mirror waiting (blocked)
+```
+
+* The focus row expands just enough detail to confirm the EFI + primary partition while still respecting the width budget.
+* Rows that would overflow (`md0`, `VG main`, LV list) compress to single-line summaries with counts (`(3 LVs)`).
+* Pending blockers (no swap mirror yet) surface as parenthetical annotations instead of extra columns.

--- a/pre_nixos/tui.py
+++ b/pre_nixos/tui.py
@@ -1,29 +1,660 @@
 """Interactive TUI for manual disk provisioning.
 
-This module renders the storage plan, allows basic edits, and lets the
-user apply the plan.  It intentionally covers only a subset of possible
-customisations; advanced users can edit the plan file directly.
+The refreshed interface renders the storage plan pictorially with
+disk→array→VG→LV lanes, adapts density to the current terminal, and still
+exposes the existing editing and apply workflows.
 """
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 import curses
 import json
-from typing import Any
+from typing import Any, Iterable, Optional, Sequence, Tuple
 
 from . import inventory, planner, apply, network
 
 
-def _draw_plan(stdscr: curses.window, plan: dict[str, Any]) -> None:
-    """Display the current plan and network info."""
+FocusKey = Tuple[str, str, Optional[str]]
+
+
+@dataclass
+class RenderResult:
+    """Container for the rendered canvas."""
+
+    lines: list[str]
+    row_tokens: list[FocusKey | None]
+    focusables: list[FocusKey]
+    profile: str
+    warnings: list[str]
+    fits: bool = True
+
+
+@dataclass
+class RowData:
+    """Intermediate representation for tabular rows."""
+
+    columns: list[str]
+    focus: FocusKey | None
+    branch: str | None
+
+
+PROFILE_SEQUENCE: Sequence[str] = ("auto", "detailed", "compact", "minimal")
+
+
+def _trim(text: str, width: int) -> str:
+    """Return ``text`` truncated to ``width`` columns with ellipsis."""
+
+    if width <= 0:
+        return ""
+    if len(text) <= width:
+        return text
+    if width == 1:
+        return text[:1]
+    return text[: width - 1] + "…"
+
+
+class PlanRenderer:
+    """Prepare textual representations of a storage plan."""
+
+    LEGEND = "Legend: ■ SSD  ● HDD  ☐ EFI  ≡ RAID"
+
+    _PROFILE_SETTINGS = {
+        "detailed": {
+            "min_widths": (28, 22, 18, 20),
+            "weights": (0.40, 0.20, 0.20, 0.20),
+        },
+        "compact": {
+            "min_widths": (22, 18, 16, 16),
+            "weights": (0.40, 0.25, 0.20, 0.15),
+        },
+    }
+
+    def __init__(self, plan: dict[str, Any], disks: list[inventory.Disk]):
+        self.plan = plan or {}
+        self.disks = {disk.name: disk for disk in disks}
+
+        partitions = self.plan.get("partitions", {})
+        self.partitions: dict[str, list[dict[str, str]]] = {
+            disk: list(parts) for disk, parts in partitions.items()
+        }
+        self.arrays = {arr["name"]: arr for arr in self.plan.get("arrays", [])}
+        self.device_to_array: dict[str, str] = {}
+        for arr in self.plan.get("arrays", []):
+            for dev in arr.get("devices", []):
+                self.device_to_array[dev] = arr["name"]
+
+        self.device_to_vgs: dict[str, list[str]] = {}
+        for vg in self.plan.get("vgs", []):
+            for dev in vg.get("devices", []):
+                self.device_to_vgs.setdefault(dev, []).append(vg["name"])
+
+        self.vg_to_lvs: dict[str, list[dict[str, str]]] = {}
+        for lv in self.plan.get("lvs", []):
+            self.vg_to_lvs.setdefault(lv["vg"], []).append(lv)
+
+        self.partition_to_disk: dict[str, str] = {}
+        for disk_name, parts in self.partitions.items():
+            for part in parts:
+                self.partition_to_disk[part["name"]] = disk_name
+
+        self.disk_order = list(self.partitions.keys())
+        if not self.disk_order and self.disks:
+            self.disk_order = sorted(self.disks.keys())
+
+        self.array_to_disks: dict[str, set[str]] = {}
+        for name, arr in self.arrays.items():
+            members = set()
+            for dev in arr.get("devices", []):
+                disk = self.partition_to_disk.get(dev)
+                if disk:
+                    members.add(disk)
+            self.array_to_disks[name] = members
+
+        self.vg_to_disks: dict[str, set[str]] = {}
+        for vg in self.plan.get("vgs", []):
+            disks_for_vg: set[str] = set()
+            for dev in vg.get("devices", []):
+                if dev in self.arrays:
+                    disks_for_vg.update(self.array_to_disks.get(dev, set()))
+                else:
+                    disk = self.partition_to_disk.get(dev)
+                    if disk:
+                        disks_for_vg.add(disk)
+            self.vg_to_disks[vg["name"]] = disks_for_vg
+
+        self.disk_to_vgs: dict[str, list[str]] = {}
+        for disk_name, parts in self.partitions.items():
+            seen: set[str] = set()
+            ordered: list[str] = []
+            for part in parts:
+                key = self.device_to_array.get(part["name"], part["name"])
+                for vg_name in self.device_to_vgs.get(key, []):
+                    if vg_name not in seen:
+                        ordered.append(vg_name)
+                        seen.add(vg_name)
+            self.disk_to_vgs[disk_name] = ordered
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+    def describe_focus(self, focus: FocusKey | None) -> str:
+        if focus is None:
+            return "none"
+        kind, primary, secondary = focus
+        if kind == "disk":
+            return f"Disk {primary}"
+        if kind == "array":
+            return f"Array {primary}"
+        if kind == "vg":
+            return f"VG {primary}"
+        if kind == "lv" and secondary:
+            return f"LV {secondary} (VG {primary})"
+        return primary
+
+    def disks_for_focus(self, focus: FocusKey | None) -> set[str]:
+        if focus is None:
+            return set()
+        kind, primary, _ = focus
+        if kind == "disk":
+            return {primary}
+        if kind == "array":
+            return set(self.array_to_disks.get(primary, set()))
+        if kind in {"vg", "lv"}:
+            return set(self.vg_to_disks.get(primary, set()))
+        return set()
+
+    # ------------------------------------------------------------------
+    # Rendering pipeline
+    # ------------------------------------------------------------------
+    def render(
+        self,
+        width: int,
+        height: int,
+        focus: FocusKey | None,
+        profile_hint: str,
+        expanded: Iterable[FocusKey],
+    ) -> RenderResult:
+        order: list[str]
+        if profile_hint == "auto":
+            order = ["detailed", "compact", "minimal"]
+        else:
+            order = [profile_hint] + [p for p in ("detailed", "compact", "minimal") if p != profile_hint]
+
+        fallback: RenderResult | None = None
+        for profile in order:
+            if profile == "minimal":
+                layout = self._build_minimal_layout(width, height, focus, expanded)
+            else:
+                layout = self._build_tabular_layout(width, height, profile)
+            if layout is None:
+                continue
+            layout.profile = profile
+            if layout.fits:
+                return layout
+            fallback = layout
+
+        if fallback is None:
+            line = _trim("No planned storage to display", width)
+            return RenderResult(
+                lines=[line],
+                row_tokens=[None],
+                focusables=[],
+                profile="minimal",
+                warnings=["no storage plan"],
+                fits=True,
+            )
+
+        if len(fallback.lines) > height:
+            overflow = len(fallback.lines) - height
+            fallback.lines = fallback.lines[:height]
+            fallback.row_tokens = fallback.row_tokens[:height]
+            fallback.warnings.append(f"truncated {overflow} line(s)")
+        fallback.fits = True
+        return fallback
+
+    # ------------------------------------------------------------------
+    # Tabular layout (detailed & compact)
+    # ------------------------------------------------------------------
+    def _build_tabular_layout(
+        self, width: int, height: int, profile: str
+    ) -> RenderResult | None:
+        settings = self._PROFILE_SETTINGS.get(profile)
+        if not settings:
+            return None
+        col_widths = self._column_widths(width, settings)
+        if col_widths is None:
+            return None
+
+        rows = self._generate_rows(profile)
+        if not rows:
+            line = _trim("No planned storage to display", width)
+            return RenderResult(
+                lines=[line],
+                row_tokens=[None],
+                focusables=[],
+                profile=profile,
+                warnings=[],
+                fits=True,
+            )
+
+        focusables: list[FocusKey] = []
+        seen_focus: set[FocusKey] = set()
+        lines: list[str] = []
+        row_tokens: list[FocusKey | None] = []
+        for row in rows:
+            padded = [self._pad(col, col_widths[idx]) for idx, col in enumerate(row.columns)]
+            line = "  ".join(padded).rstrip()
+            lines.append(_trim(line, width))
+            row_tokens.append(row.focus)
+            if row.focus and row.focus not in seen_focus:
+                focusables.append(row.focus)
+                seen_focus.add(row.focus)
+
+        fits = len(lines) <= height
+        return RenderResult(
+            lines=lines,
+            row_tokens=row_tokens,
+            focusables=focusables,
+            profile=profile,
+            warnings=[],
+            fits=fits,
+        )
+
+    def _generate_rows(self, profile: str) -> list[RowData]:
+        rows: list[RowData] = []
+        for disk_name in self.disk_order:
+            partitions = self.partitions.get(disk_name, [])
+            disk_label = self._format_disk_label(profile, disk_name, partitions)
+            data_parts = [part for part in partitions if part.get("type") != "efi"]
+
+            if not data_parts:
+                rows.append(
+                    RowData([disk_label, "", "", ""], ("disk", disk_name, None), disk_name)
+                )
+                continue
+
+            disk_row_started = False
+            for part in data_parts:
+                source_name = self.device_to_array.get(part["name"])
+                source_label = self._format_source_label(profile, source_name, part, disk_name)
+                connector = self._continuation()
+                vgs = self._vgs_for_source(source_name, part)
+
+                if not vgs:
+                    columns = [disk_label if not disk_row_started else "", source_label, "", ""]
+                    focus: FocusKey | None
+                    if source_name:
+                        focus = ("array", source_name, None)
+                    else:
+                        focus = ("disk", disk_name, None)
+                    rows.append(RowData(columns, focus, disk_name))
+                    disk_row_started = True
+                    continue
+
+                source_first = True
+                for vg_name in vgs:
+                    vg_label = self._format_vg_label(profile, vg_name)
+                    lvs = self.vg_to_lvs.get(vg_name, [])
+                    vg_connector = connector
+
+                    if not lvs:
+                        columns = [
+                            disk_label if not disk_row_started else "",
+                            source_label if source_first else connector,
+                            vg_label if source_first else vg_connector,
+                            "",
+                        ]
+                        rows.append(RowData(columns, ("vg", vg_name, None), disk_name))
+                        disk_row_started = True
+                        source_first = False
+                        continue
+
+                    lv_first = True
+                    for lv in lvs:
+                        columns = [
+                            disk_label if not disk_row_started else "",
+                            source_label if source_first and lv_first else connector,
+                            vg_label if source_first and lv_first else vg_connector,
+                            self._format_lv_label(profile, lv),
+                        ]
+                        rows.append(RowData(columns, ("lv", vg_name, lv["name"]), disk_name))
+                        disk_row_started = True
+                        lv_first = False
+                        source_first = False
+
+            # end partitions
+        return rows
+
+    # ------------------------------------------------------------------
+    # Minimal layout (auto-collapsing)
+    # ------------------------------------------------------------------
+    def _build_minimal_layout(
+        self,
+        width: int,
+        height: int,
+        focus: FocusKey | None,
+        expanded: Iterable[FocusKey],
+    ) -> RenderResult:
+        lines: list[str] = []
+        row_tokens: list[FocusKey | None] = []
+        focusables: list[FocusKey] = []
+
+        focus_disks = self.disks_for_focus(focus)
+        expanded_disks: set[str] = set()
+        for token in expanded:
+            expanded_disks.update(self.disks_for_focus(token))
+
+        disks_iter = self.disk_order or sorted(self.disks.keys())
+        if not disks_iter:
+            line = _trim("No planned storage to display", width)
+            return RenderResult(
+                lines=[line],
+                row_tokens=[None],
+                focusables=[],
+                profile="minimal",
+                warnings=[],
+                fits=True,
+            )
+
+        for disk_name in disks_iter:
+            summary = self._minimal_disk_summary(disk_name)
+            token: FocusKey = ("disk", disk_name, None)
+            lines.append(_trim(summary, width))
+            row_tokens.append(token)
+            if token not in focusables:
+                focusables.append(token)
+
+            if disk_name not in focus_disks and disk_name not in expanded_disks:
+                continue
+
+            for vg_name in self.disk_to_vgs.get(disk_name, []):
+                vg_line = f"   ⇒ {self._minimal_vg_summary(vg_name)}"
+                vg_token: FocusKey = ("vg", vg_name, None)
+                lines.append(_trim(vg_line, width))
+                row_tokens.append(vg_token)
+                if vg_token not in focusables:
+                    focusables.append(vg_token)
+
+                for lv in self.vg_to_lvs.get(vg_name, []):
+                    lv_line = f"      - {self._format_lv_label('minimal', lv)}"
+                    lv_token: FocusKey = ("lv", vg_name, lv["name"])
+                    lines.append(_trim(lv_line, width))
+                    row_tokens.append(lv_token)
+                    if lv_token not in focusables:
+                        focusables.append(lv_token)
+
+        fits = len(lines) <= height
+        return RenderResult(
+            lines=lines,
+            row_tokens=row_tokens,
+            focusables=focusables,
+            profile="minimal",
+            warnings=[],
+            fits=fits,
+        )
+
+    # ------------------------------------------------------------------
+    # Formatting helpers
+    # ------------------------------------------------------------------
+    def _column_widths(self, width: int, settings: dict[str, Sequence[float]]) -> list[int] | None:
+        min_widths = list(settings["min_widths"])
+        weights = list(settings["weights"])
+        gaps = (len(min_widths) - 1) * 2
+        base_total = sum(min_widths) + gaps
+        if width < base_total:
+            return None
+
+        extra = width - base_total
+        col_widths = min_widths[:]
+        for idx, weight in enumerate(weights):
+            if extra <= 0:
+                break
+            add = int(extra * weight)
+            col_widths[idx] += add
+            extra -= add
+        idx = 0
+        while extra > 0:
+            col_widths[idx % len(col_widths)] += 1
+            extra -= 1
+            idx += 1
+        return col_widths
+
+    def _pad(self, text: str, width: int) -> str:
+        if len(text) >= width:
+            return _trim(text, width)
+        return text.ljust(width)
+
+    def _disk_icon(self, disk_name: str) -> str:
+        disk = self.disks.get(disk_name)
+        if disk is None:
+            return "◆"
+        if disk.rotational:
+            return "◎"
+        return "⟟"
+
+    def _partition_symbol(self, disk_name: str) -> str:
+        disk = self.disks.get(disk_name)
+        if disk and disk.rotational:
+            return "●"
+        return "■"
+
+    def _format_disk_label(
+        self, profile: str, disk_name: str, partitions: list[dict[str, str]]
+    ) -> str:
+        icon = self._disk_icon(disk_name)
+        pieces = [f"Disk {disk_name}", icon]
+        if partitions:
+            part_texts: list[str] = []
+            for part in partitions:
+                if part.get("type") == "efi":
+                    label = "EFI" if profile != "compact" else "E"
+                    part_texts.append(f"[☐ {label}]")
+                else:
+                    name = part.get("name", "?")
+                    if profile == "compact":
+                        name = name[-4:]
+                    part_texts.append(f"[{self._partition_symbol(disk_name)} {name}]")
+            if part_texts:
+                pieces.append(" ".join(part_texts))
+        return "  ".join(pieces).strip()
+
+    def _format_source_label(
+        self,
+        profile: str,
+        array_name: str | None,
+        part: dict[str, str],
+        disk_name: str,
+    ) -> str:
+        if array_name:
+            array = self.arrays.get(array_name)
+            if not array:
+                return array_name
+            level = array.get("level", "").upper()
+            if level and level.startswith("RAID") and profile == "compact":
+                level = level.replace("RAID", "R")
+            if level == "SINGLE":
+                level = "single"
+            typ = array.get("type")
+            tier = ""
+            if typ:
+                tier = typ.upper()
+            connector = "≡ " if array.get("level") != "single" else ""
+            text = f"{array_name} {connector}{level}".strip()
+            if tier:
+                text = f"{text} ({tier})"
+            return text
+
+        name = part.get("name", "?")
+        if profile == "compact":
+            name = name[-4:]
+        return f"PV {name}"
+
+    def _format_vg_label(self, profile: str, vg_name: str) -> str:
+        return f"VG {vg_name}"
+
+    def _format_lv_label(self, profile: str, lv: dict[str, str]) -> str:
+        size = lv.get("size")
+        if profile == "minimal":
+            if size:
+                return f"{lv.get('name')} {size}"
+            return lv.get("name", "LV")
+        if size:
+            return f"{lv.get('name')} {size}"
+        return lv.get("name", "LV")
+
+    def _minimal_disk_summary(self, disk_name: str) -> str:
+        icon = self._disk_icon(disk_name)
+        vgs = self.disk_to_vgs.get(disk_name, [])
+        if not vgs:
+            suffix = "no VGs planned"
+        else:
+            parts: list[str] = []
+            for vg in vgs:
+                count = len(self.vg_to_lvs.get(vg, []))
+                if count == 0:
+                    parts.append(f"{vg}")
+                elif count == 1:
+                    parts.append(f"{vg} (1 LV)")
+                else:
+                    parts.append(f"{vg} ({count} LVs)")
+            suffix = "  ".join(parts)
+        return f"Disk {disk_name} {icon}  {suffix}".strip()
+
+    def _minimal_vg_summary(self, vg_name: str) -> str:
+        lvs = self.vg_to_lvs.get(vg_name, [])
+        if not lvs:
+            return f"VG {vg_name}"
+        names = [lv.get("name", "LV") for lv in lvs[:3]]
+        text = ", ".join(names)
+        if len(lvs) > 3:
+            text += ", …"
+        return f"VG {vg_name} → {text}"
+
+    def _continuation(self) -> str:
+        return "└─"
+
+    def _vgs_for_source(self, array_name: str | None, part: dict[str, str]) -> list[str]:
+        key = array_name if array_name else part.get("name")
+        if not key:
+            return []
+        return list(self.device_to_vgs.get(key, []))
+
+
+@dataclass
+class TUIState:
+    """Mutable state shared between frames."""
+
+    plan: dict[str, Any]
+    disks: list[inventory.Disk]
+    renderer: PlanRenderer
+    focus: FocusKey | None = None
+    profile_override: str = "auto"
+    expanded: set[FocusKey] = field(default_factory=set)
+
+
+def _initial_state(plan: dict[str, Any], disks: list[inventory.Disk]) -> TUIState:
+    """Create a :class:`TUIState` from the current plan and inventory."""
+
+    return TUIState(plan=plan, disks=disks, renderer=PlanRenderer(plan, disks))
+
+
+def _draw_plan(stdscr: curses.window, state: TUIState) -> RenderResult:
+    """Display the current plan using the adaptive renderer."""
+
     stdscr.clear()
     status = network.get_lan_status()
     height, width = stdscr.getmaxyx()
-    stdscr.addstr(0, 0, f"IP: {status}")
-    lines = json.dumps(plan, indent=2).splitlines()
-    for idx, line in enumerate(lines[: height - 3]):
-        stdscr.addstr(idx + 1, 0, line[: width - 1])
-    stdscr.addstr(height - 2, 0, "[E]dit  [S]ave  [L]oad  [A]pply  [Q]uit")
+    header_rows = 2
+    footer_rows = 1
+    canvas_height = max(height - header_rows - footer_rows, 0)
+    canvas_width = max(width - 2, 10)
+
+    render = state.renderer.render(
+        canvas_width, canvas_height, state.focus, state.profile_override, state.expanded
+    )
+
+    if render.focusables:
+        if state.focus not in render.focusables:
+            state.focus = render.focusables[0]
+    else:
+        state.focus = None
+
+    focus_label = state.renderer.describe_focus(state.focus)
+    header = f"IP: {status}  View: Planned  Focus: {focus_label}  Profile: {render.profile}"
+    stdscr.addstr(0, 0, _trim(header, width - 1))
+    stdscr.addstr(1, 0, _trim(PlanRenderer.LEGEND, width - 1))
+
+    start_y = header_rows
+    max_lines = min(canvas_height, len(render.lines))
+    for idx in range(max_lines):
+        line = render.lines[idx]
+        token = render.row_tokens[idx] if idx < len(render.row_tokens) else None
+        prefix = "▶ " if token is not None and token == state.focus else "  "
+        stdscr.addstr(start_y + idx, 0, _trim(prefix + line, width - 1))
+
+    footer_parts = [
+        "[↑/↓] Move",
+        "[Enter] Expand",
+        "[Z] Zoom",
+        "[E]dit",
+        "[S]ave",
+        "[L]oad",
+        "[A]pply",
+        "[Q]uit",
+    ]
+    footer = "  ".join(footer_parts)
+    if render.warnings:
+        footer = f"{footer}  ⚠ {' | '.join(render.warnings)}"
+    stdscr.addstr(height - 1, 0, _trim(footer, width - 1))
     stdscr.refresh()
+    return render
+
+
+def _move_focus(state: TUIState, render: RenderResult, direction: int) -> None:
+    """Move the focus cursor up or down by one logical row."""
+
+    tokens = render.row_tokens
+    if not tokens:
+        return
+    if state.focus is None:
+        for token in tokens:
+            if token is not None:
+                state.focus = token
+                return
+        return
+
+    try:
+        current_index = next(i for i, tok in enumerate(tokens) if tok == state.focus)
+    except StopIteration:
+        current_index = -1 if direction > 0 else len(tokens)
+
+    if direction > 0:
+        search = range(current_index + 1, len(tokens))
+        wrap = range(0, len(tokens))
+    else:
+        search = range(current_index - 1, -1, -1)
+        wrap = range(len(tokens) - 1, -1, -1)
+
+    for idx in search:
+        token = tokens[idx]
+        if token is not None:
+            state.focus = token
+            return
+    for idx in wrap:
+        token = tokens[idx]
+        if token is not None:
+            state.focus = token
+            return
+
+
+def _cycle_profile(current: str) -> str:
+    """Return the next profile override value."""
+
+    try:
+        idx = PROFILE_SEQUENCE.index(current)
+    except ValueError:
+        idx = 0
+    return PROFILE_SEQUENCE[(idx + 1) % len(PROFILE_SEQUENCE)]
 
 
 def _edit_plan(stdscr: curses.window, plan: dict[str, Any]) -> None:
@@ -109,31 +740,71 @@ def _load_plan(stdscr: curses.window, plan: dict[str, Any]) -> dict[str, Any]:
 
 def run() -> None:
     """Launch the interactive provisioning TUI."""
+
     disks = inventory.enumerate_disks()
     ram_gb = inventory.detect_ram_gb()
     plan = planner.plan_storage("fast", disks, ram_gb=ram_gb)
+    state = _initial_state(plan, disks)
+
+    def refresh_renderer() -> None:
+        state.renderer = PlanRenderer(state.plan, state.disks)
+        state.focus = None
+        state.expanded.clear()
 
     def _main(stdscr: curses.window) -> None:
-        nonlocal plan
+        try:
+            curses.curs_set(0)
+        except curses.error:
+            pass
+
         while True:
-            _draw_plan(stdscr, plan)
-            ch = stdscr.getkey().lower()
-            if ch == "q":
+            render = _draw_plan(stdscr, state)
+            try:
+                key = stdscr.getkey()
+            except curses.error:
+                continue
+
+            key_lower = key.lower() if len(key) == 1 else key
+
+            if key_lower == "KEY_RESIZE":
+                continue
+            if key_lower == "q":
                 break
-            if ch == "e":
-                _edit_plan(stdscr, plan)
-            if ch == "s":
-                _save_plan(stdscr, plan)
-            if ch == "l":
-                plan = _load_plan(stdscr, plan)
-            if ch == "a":
+            if key_lower == "e":
+                _edit_plan(stdscr, state.plan)
+                refresh_renderer()
+                continue
+            if key_lower == "s":
+                _save_plan(stdscr, state.plan)
+                continue
+            if key_lower == "l":
+                state.plan = _load_plan(stdscr, state.plan)
+                refresh_renderer()
+                continue
+            if key_lower == "a":
                 stdscr.clear()
                 stdscr.addstr(0, 0, "Applying plan...\n")
                 stdscr.refresh()
-                apply.apply_plan(plan)
+                apply.apply_plan(state.plan)
                 stdscr.addstr(1, 0, "Done. Press any key to exit.")
                 stdscr.getkey()
                 break
+            if key_lower in {"KEY_UP", "k"}:
+                _move_focus(state, render, -1)
+                continue
+            if key_lower in {"KEY_DOWN", "j"}:
+                _move_focus(state, render, 1)
+                continue
+            if key_lower in {"KEY_ENTER", "\n", "\r"}:
+                if state.focus is not None:
+                    if state.focus in state.expanded:
+                        state.expanded.remove(state.focus)
+                    else:
+                        state.expanded.add(state.focus)
+                continue
+            if key_lower == "z":
+                state.profile_override = _cycle_profile(state.profile_override)
+                continue
 
     curses.wrapper(_main)
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,88 +1,169 @@
 import json
+import pytest
+
 from pre_nixos import inventory
 import pre_nixos.tui as tui
+
+
+class FakeWindow:
+    """Minimal stand-in for a curses window used in tests."""
+
+    def __init__(self, height: int = 25, width: int = 100):
+        self.height = height
+        self.width = width
+        self.lines: dict[int, str] = {}
+        self.buffer: list[str] = []
+
+    def clear(self) -> None:  # pragma: no cover - behaviour is a no-op
+        pass
+
+    def refresh(self) -> None:  # pragma: no cover - behaviour is a no-op
+        pass
+
+    def getmaxyx(self) -> tuple[int, int]:
+        return (self.height, self.width)
+
+    def addstr(self, *args):
+        if len(args) == 1:
+            self.buffer.append(args[0])
+            return
+        y, _x, text = args
+        self.lines[y] = text
+
+    def getstr(self):  # pragma: no cover - only used for save/load tests
+        raise NotImplementedError("FakeWindow requires explicit inputs")
+
+
+@pytest.fixture
+def sample_plan() -> dict:
+    return {
+        "partitions": {
+            "nvme0n1": [
+                {"name": "nvme0n1p1", "type": "efi"},
+                {"name": "nvme0n1p2", "type": "lvm"},
+            ],
+            "sda": [
+                {"name": "sda1", "type": "lvm"},
+                {"name": "sda2", "type": "lvm"},
+            ],
+        },
+        "arrays": [
+            {
+                "name": "md0",
+                "level": "raid1",
+                "devices": ["nvme0n1p2", "sda1"],
+                "type": "ssd",
+            }
+        ],
+        "vgs": [
+            {"name": "main", "devices": ["md0"]},
+            {"name": "bulk", "devices": ["sda2"]},
+        ],
+        "lvs": [
+            {"name": "root", "vg": "main", "size": "50G"},
+            {"name": "home", "vg": "main", "size": "100G"},
+            {"name": "data", "vg": "bulk", "size": "1T"},
+        ],
+    }
+
+
+@pytest.fixture
+def sample_disks() -> list[inventory.Disk]:
+    return [
+        inventory.Disk(name="nvme0n1", rotational=False, nvme=True),
+        inventory.Disk(name="sda", rotational=True, nvme=False),
+    ]
+
+
+@pytest.fixture
+def renderer(sample_plan, sample_disks) -> tui.PlanRenderer:
+    return tui.PlanRenderer(sample_plan, sample_disks)
+
+
+@pytest.fixture
+def state(sample_plan, sample_disks) -> tui.TUIState:
+    return tui._initial_state(sample_plan, sample_disks)
 
 
 def test_tui_exposes_run():
     assert callable(tui.run)
 
 
-def _sample_state():
-    plan = {
-        "partitions": {
-            "nvme0n1": [
-                {"name": "nvme0n1p1", "type": "efi"},
-                {"name": "nvme0n1p2", "type": "lvm"},
-            ]
-        },
-        "arrays": [],
-        "vgs": [{"name": "main", "devices": ["nvme0n1p2"]}],
-        "lvs": [{"name": "root", "vg": "main", "size": "50G"}],
-    }
-    disks = [inventory.Disk(name="nvme0n1", rotational=False, nvme=True)]
-    return tui._initial_state(plan, disks)
+def test_plan_renderer_prefers_detailed_profile(renderer):
+    render = renderer.render(100, 20, None, "auto", expanded=())
+    assert render.profile == "detailed"
+    assert render.focusables[0] == ("lv", "main", "root")
+    assert render.lines[0].startswith("Disk nvme0n1")
 
 
-def test_draw_plan_displays_ip(monkeypatch):
-    class FakeWin:
-        def __init__(self):
-            self.lines = {}
+def test_plan_renderer_falls_back_to_minimal(renderer):
+    render = renderer.render(40, 10, None, "auto", expanded=())
+    assert render.profile == "minimal"
+    assert render.focusables[0] == ("disk", "nvme0n1", None)
+    assert any("Disk nvme0n1" in line for line in render.lines)
 
-        def clear(self):
-            pass
 
-        def getmaxyx(self):
-            return (25, 80)
+def test_minimal_layout_expands_focus(renderer):
+    focus = ("vg", "main", None)
+    render = renderer.render(40, 10, focus, "minimal", expanded={focus})
+    assert any("⇒ VG main" in line for line in render.lines)
+    assert any("root 50G" in line for line in render.lines)
+    assert focus in render.focusables
 
-        def addstr(self, y, x, s):
-            self.lines[y] = s
 
-        def refresh(self):
-            pass
-
-    win = FakeWin()
+def test_draw_plan_assigns_initial_focus(monkeypatch, state):
+    win = FakeWindow(height=20, width=100)
     monkeypatch.setattr(tui.network, "get_lan_status", lambda: "203.0.113.7")
-    state = _sample_state()
-    tui._draw_plan(win, state)
+    render = tui._draw_plan(win, state)
     assert "203.0.113.7" in win.lines[0]
-    canvas = [line for y, line in win.lines.items() if y >= 2]
-    assert any("Disk nvme0n1" in line for line in canvas)
+    assert state.focus is not None
+    first_canvas_row = min(y for y in win.lines if y >= 2)
+    assert win.lines[first_canvas_row].startswith("▶ ")
+    assert render is not None
 
 
-def test_draw_plan_displays_messages(monkeypatch):
-    class FakeWin:
-        def __init__(self):
-            self.lines = {}
-
-        def clear(self):
-            pass
-
-        def getmaxyx(self):
-            return (25, 80)
-
-        def addstr(self, y, x, s):
-            self.lines[y] = s
-
-        def refresh(self):
-            pass
-
-    win = FakeWin()
+def test_draw_plan_displays_messages(monkeypatch, state):
+    win = FakeWindow(height=20, width=100)
     monkeypatch.setattr(tui.network, "get_lan_status", lambda: "missing SSH public key")
-    state = _sample_state()
     tui._draw_plan(win, state)
     assert "missing SSH public key" in win.lines[0]
 
 
+def test_move_focus_wraps_and_skips_empty_tokens():
+    state = tui._initial_state({}, [])
+    render = tui.RenderResult(
+        lines=["", "", "", ""],
+        row_tokens=[None, ("disk", "one", None), None, ("vg", "vg1", None)],
+        focusables=[("disk", "one", None), ("vg", "vg1", None)],
+        profile="minimal",
+        warnings=[],
+        fits=True,
+    )
+
+    state.focus = None
+    tui._move_focus(state, render, 1)
+    assert state.focus == ("disk", "one", None)
+
+    tui._move_focus(state, render, -1)
+    assert state.focus == ("vg", "vg1", None)
+
+    tui._move_focus(state, render, 1)
+    assert state.focus == ("disk", "one", None)
+
+
+def test_cycle_profile_loops_through_sequence():
+    sequence = ["auto", "detailed", "compact", "minimal", "auto"]
+    current = sequence[0]
+    for expected in sequence[1:]:
+        current = tui._cycle_profile(current)
+        assert current == expected
+
+
 def test_save_and_load_plan(tmp_path, monkeypatch):
-    class FakeWin:
+    class PromptWindow(FakeWindow):
         def __init__(self, inputs):
+            super().__init__()
             self._inputs = inputs
-
-        def clear(self):
-            pass
-
-        def addstr(self, *args):
-            pass
 
         def getstr(self):
             return self._inputs.pop(0)
@@ -93,10 +174,10 @@ def test_save_and_load_plan(tmp_path, monkeypatch):
     plan = {"a": 1}
     path = tmp_path / "plan.json"
 
-    win = FakeWin([str(path).encode()])
+    win = PromptWindow([str(path).encode()])
     tui._save_plan(win, plan)
     assert json.loads(path.read_text()) == plan
 
-    win = FakeWin([str(path).encode()])
+    win = PromptWindow([str(path).encode()])
     loaded = tui._load_plan(win, {"old": 0})
     assert loaded == plan


### PR DESCRIPTION
## Summary
- replace the curses JSON dump with an adaptive renderer that lays out disks, arrays, VGs, and LVs across four lanes and auto-selects detailed, compact, or minimal density based on the terminal size
- introduce focus-aware navigation with arrow keys, a zoom/profile cycle shortcut, and focus-preserving branch expansion so operators can drill into the plan pictorially
- update the TUI tests to exercise the new renderer by feeding a sample plan and asserting the IP header and disk lanes render correctly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfed194e3c832fbeedeeb3183b2680