### PR TITLE
Ensure swap LV on SSD-only systems

### DIFF
--- a/pre_nixos/planner.py
+++ b/pre_nixos/planner.py
@@ -221,8 +221,8 @@ def plan_storage(
             add_array(name, arr["level"], devices, "hdd")
             add_vg("main", [name])
         swap_size = f"{ram_gb * 2 * 1024}M"
-        add_lv("swap", "main", swap_size)
         add_lv("root", "main", ROOT_LV_SIZE)
+        add_lv("swap", "main", swap_size)
         return plan
 
     for idx, bucket in enumerate(ssd_buckets):
@@ -294,10 +294,15 @@ def plan_storage(
             (vg["name"] for vg in plan["vgs"] if vg["name"].startswith("large")),
             None,
         )
-    if swap_vg is not None:
-        add_lv("swap", swap_vg, swap_size)
+    if swap_vg is None and not hdd_buckets:
+        swap_vg = next(
+            (vg["name"] for vg in plan["vgs"] if vg["name"] == "main"),
+            None,
+        )
     if any(vg["name"] == "main" for vg in plan["vgs"]):
         add_lv("root", "main", ROOT_LV_SIZE)
+    if swap_vg is not None:
+        add_lv("swap", swap_vg, swap_size)
     if any(vg["name"].startswith("large") for vg in plan["vgs"]):
         add_lv("data", "large", DATA_LV_SIZE)
 

--- a/tests/test_plan_storage.py
+++ b/tests/test_plan_storage.py
@@ -107,16 +107,16 @@ def test_single_hdd_with_ssd_gets_swap_vg() -> None:
     assert all(p["type"] == "lvm" for p in plan["partitions"]["sdb"])
 
 
-def test_ssd_only_has_no_swap() -> None:
+def test_ssd_only_has_swap_lv_in_main() -> None:
     disks = [
         Disk(name="sda", size=1000, rotational=False),
         Disk(name="sdb", size=1000, rotational=False),
     ]
     plan = plan_storage("fast", disks)
     vg_names = {vg["name"] for vg in plan["vgs"]}
-    lv_names = {lv["name"] for lv in plan["lvs"]}
-    assert "swap" not in vg_names
-    assert "swap" not in lv_names
+    assert vg_names == {"main"}
+    swap_lv = next(lv for lv in plan["lvs"] if lv["name"] == "swap")
+    assert swap_lv["vg"] == "main"
 
 
 def test_swap_lv_falls_back_to_large_vg() -> None:


### PR DESCRIPTION
## Summary
- ensure the storage planner falls back to the main VG for swap creation when only SSDs are detected
- allocate the root LV before swap so the root filesystem is always provisioned
- update SSD-only planner tests to expect the swap LV on the main VG

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0695af994832f8b386583ae162dab