### PR TITLE
Include minicom in boot image

### DIFF
--- a/modules/pre-nixos.nix
+++ b/modules/pre-nixos.nix
@@ -11,7 +11,7 @@ in {
   options.services.pre-nixos.enable = lib.mkEnableOption "run pre-nixos planning tool";
 
   config = lib.mkIf cfg.enable {
-    environment.systemPackages = [ pkgs.pre-nixos pkgs.util-linux ];
+    environment.systemPackages = [ pkgs.pre-nixos pkgs.util-linux pkgs.minicom ];
     environment.sessionVariables = preNixosExecEnv;
     environment.interactiveShellInit = preNixosLoginNotice;
     boot.kernelParams = [ "console=ttyS0,115200n8" "console=tty0" ];


### PR DESCRIPTION
## Summary
- include `pkgs.minicom` in the pre-nixos boot image's system packages so the serial console utility is available at boot

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d546568058832fa89b54f189f5f0bf