### PR TITLE
Enable memtest86+ in boot image

### DIFF
--- a/modules/pre-nixos.nix
+++ b/modules/pre-nixos.nix
@@ -15,6 +15,7 @@ in {
     environment.sessionVariables = preNixosExecEnv;
     environment.interactiveShellInit = preNixosLoginNotice;
     boot.kernelParams = [ "console=ttyS0,115200n8" "console=tty0" ];
+    boot.loader.grub.memtest86.enable = true;
     boot.loader.grub.extraConfig = ''
       serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1
       terminal_input serial console


### PR DESCRIPTION
## Summary
- enable memtest86+ entry in the GRUB boot menu for the pre-NixOS ISO

## Testing
- nix flake check *(fails: command not found: nix)*

------
https://chatgpt.com/codex/tasks/task_e_68d60151b260832f96a9ac256fbda37b