### PR TITLE
Fix boot image outputs to avoid stale package propagation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,17 +8,24 @@
 
   outputs = { self, nixpkgs, flake-utils, ... }:
     let
+      inherit (flake-utils.lib) eachDefaultSystem;
+
       rootPubPath = "${builtins.toString ./.}/pre_nixos/root_ed25519.pub";
       rootPub =
         if builtins.pathExists rootPubPath then
           builtins.path { path = builtins.toPath rootPubPath; }
         else
           null;
-    in
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs { inherit system; };
-        pre-nixos = pkgs.python3Packages.buildPythonApplication {
+
+      pkgsFor = system: nixpkgs.legacyPackages.${system};
+
+      preNixosModule = import ./modules/pre-nixos.nix;
+
+      makePreNixosPackage = system:
+        let
+          pkgs = pkgsFor system;
+        in
+        pkgs.python3Packages.buildPythonApplication {
           pname = "pre-nixos";
           version = "0.1.0";
           src = ./.;
@@ -29,34 +36,44 @@
             cp ${rootPub} pre_nixos/root_ed25519.pub
           '';
         };
+
+      preInstallerSystem = "x86_64-linux";
+      preInstallerPackage = makePreNixosPackage preInstallerSystem;
+      preInstallerOverlay = _: _: { pre-nixos = preInstallerPackage; };
+
+      preInstallerConfig = nixpkgs.lib.nixosSystem {
+        system = preInstallerSystem;
+        modules = [
+          ({ ... }: { nixpkgs.overlays = [ preInstallerOverlay ]; })
+          preNixosModule
+          "${nixpkgs}/nixos/modules/installer/cd-dvd/iso-image.nix"
+          "${nixpkgs}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
+          ({ config, ... }: { services.pre-nixos.enable = true; })
+        ];
+      };
+    in
+    eachDefaultSystem (system:
+      let
+        pkgs = pkgsFor system;
+        preNixosPackage =
+          if system == preInstallerSystem
+          then preInstallerPackage
+          else makePreNixosPackage system;
       in {
         packages =
-          if system == "x86_64-linux" then {
-            default = self.nixosConfigurations.pre-installer.config.system.build.isoImage;
-            bootImage = self.nixosConfigurations.pre-installer.config.system.build.isoImage;
-            pre-nixos = pre-nixos;
+          if system == preInstallerSystem then {
+            default = preInstallerConfig.config.system.build.isoImage;
+            bootImage = preInstallerConfig.config.system.build.isoImage;
+            pre-nixos = preNixosPackage;
           } else {
-            default = pre-nixos;
-            pre-nixos = pre-nixos;
+            default = preNixosPackage;
+            pre-nixos = preNixosPackage;
           };
         devShells.default = pkgs.mkShell {
           buildInputs = [ pkgs.python3 pkgs.python3Packages.pytest ];
         };
       }) // {
-        nixosModules.pre-nixos = import ./modules/pre-nixos.nix;
-        nixosConfigurations.pre-installer = nixpkgs.lib.nixosSystem {
-          system = "x86_64-linux";
-          modules = [
-            ({ ... }: {
-              nixpkgs.overlays = [
-                (final: prev: { pre-nixos = self.packages.x86_64-linux.pre-nixos; })
-              ];
-            })
-            self.nixosModules.pre-nixos
-            "${nixpkgs}/nixos/modules/installer/cd-dvd/iso-image.nix"
-            "${nixpkgs}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
-            ({ config, ... }: { services.pre-nixos.enable = true; })
-          ];
-        };
-      };
+      nixosModules.pre-nixos = preNixosModule;
+      nixosConfigurations.pre-installer = preInstallerConfig;
+    };
 }


### PR DESCRIPTION
## Summary
- refactor the flake outputs to build the pre-installer NixOS configuration once and reuse it for the ISO
- expose the pre-nixos package to the ISO through a direct overlay instead of referencing previous flake outputs

## Testing
- pytest *(fails: configure_lan_skips_without_key expects no embedded SSH key but the repository includes pre_nixos/root_ed25519.pub)*

------
https://chatgpt.com/codex/tasks/task_e_68d671ce8670832f91b1e26c92d84011