### PR TITLE
Ensure swap LV planning respects EFI reservation

### DIFF
--- a/pre_nixos/planner.py
+++ b/pre_nixos/planner.py
@@ -44,6 +44,10 @@ def _format_size(size: int) -> str:
     return str(size)
 
 
+EFI_PARTITION_SIZE = _parse_size("1G")
+MI_BYTE = 1024 ** 2
+
+
 def _array_capacity(level: str, sizes: List[int]) -> int:
     """Return usable size in bytes for an array of ``sizes``."""
 
@@ -173,7 +177,12 @@ def plan_storage(
                 part_name = _part_name(d.name, idx)
                 parts.append({"name": part_name, "type": ptype})
                 plan["partitions"][d.name] = parts
-                device_sizes[part_name] = _to_bytes(d.size)
+                capacity = _to_bytes(d.size)
+                if with_efi:
+                    capacity = max(capacity - EFI_PARTITION_SIZE, 0)
+                if capacity > 0:
+                    capacity -= capacity % MI_BYTE
+                device_sizes[part_name] = capacity
             # last partition in the list is always the data one
             devices.append(plan["partitions"][d.name][-1]["name"])
         return devices


### PR DESCRIPTION
## Summary
- subtract the EFI partition from LVM capacity estimates when planning on EFI-partitioned disks, aligning to MiB to avoid over-allocation
- adjust root LV sizing expectations and add a regression test covering swap sizing on single-SSD hosts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d69942f000832fa784b9ed3281ec32