### PR TITLE
Document 2025-09-29 boot image storage failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,39 @@ The project uses [pytest](https://pytest.org) for tests.
 pytest
 ```
 
+### Virtual machine integration tests
+
+The test suite includes end-to-end checks that boot the generated ISO inside a
+QEMU virtual machine, verify that `pre-nixos` provisions a blank disk, and that
+the network interface is renamed to `lan` and receives a DHCP lease. These
+tests require the `nix` CLI to build the boot image, `qemu-system-x86_64` to run
+the VM, and the Python [`pexpect`](https://pexpect.readthedocs.io/) module for
+console automation.
+
+Before running the VM tests ensure your host `nix.conf` enables the flake
+command set:
+
+```bash
+sudo tee -a /etc/nix/nix.conf <<'EOF'
+experimental-features = nix-command flakes
+EOF
+```
+
+Run only the integration tests after installing their dependencies:
+
+```bash
+pip install pexpect
+pytest tests/test_boot_image_vm.py
+```
+
+The tests automatically skip when the required tooling is missing.
+
+> **Network requirements:** the build must be able to reach
+> `https://cache.nixos.org` for prebuilt binaries and the GNU mirrors for
+> source fallbacks. If a corporate proxy blocks these domains Nix will fail
+> while trying to download `bash-5.2.tar.gz`, preventing the VM tests from
+> booting the image.
+
 ## Nix flake
 
 Build a bootable ISO that prints the plan at boot. Run `pre-nixos-tui` manually

--- a/docs/test-reports/2024-boot-image-test.md
+++ b/docs/test-reports/2024-boot-image-test.md
@@ -1,0 +1,14 @@
+# Boot Image Test Report
+
+- **Date:** 2025-09-27 UTC
+- **Tester:** OpenAI Assistant
+- **Scope:** Automated Python test suite (`pytest`).
+
+## Summary
+All automated tests in the repository passed. No regressions or unexpected failures were observed.
+
+## Detailed Results
+- `pytest` (tests/): Passed in the provided environment.
+
+## Issues Identified
+No faults were detected; no issues were opened.

--- a/docs/test-reports/2025-09-28-boot-image-test.md
+++ b/docs/test-reports/2025-09-28-boot-image-test.md
@@ -1,0 +1,23 @@
+# Boot Image Test Report — 2025-09-28
+
+- **Tester:** Automated CI agent
+- **Command:** `pytest tests/test_boot_image_vm.py`
+- **Environment:** Ubuntu 24.04 container; Nix 2.18.1 (`nix-bin` via APT); QEMU 8.2; Python 3.11 with `pexpect`
+- **Result:** ❌ Failed — the Nix build step cannot download required sources because outbound HTTPS requests to the Nix binary cache (`cache.nixos.org`) and GNU mirrors are blocked by the execution environment's proxy.
+
+## Failure Details
+
+The integration tests invoke `nix build .#bootImage --no-link --print-out-paths`. The build aborts immediately when Nix attempts to fetch `nix-cache-info` and subsequently the `bash-5.2.tar.gz` source tarball. Both downloads terminate with `Failure when receiving data from the peer (56)` and the proxy returns HTTP 403. Without access to the binary cache or source mirrors, Nix falls back to building from source, which is impossible under these network restrictions, so the VM tests cannot proceed.
+
+Full pytest output (abridged):
+
+```
+warning: error: unable to download 'https://cache.nixos.org/nix-cache-info': Failure when receiving data from the peer (56)
+...
+error: builder for '/nix/store/5jrd75v747s76s16zxk59384xfcjqn58-bash-5.2.tar.gz.drv' failed with exit code 1
+```
+
+## Next Steps
+
+- Ensure the test environment can reach `https://cache.nixos.org/` and GNU source mirrors (`https://ftp.gnu.org/` or `https://ftpmirror.gnu.org/`).
+- Re-run `pytest tests/test_boot_image_vm.py` once network access is restored to confirm the boot image builds and boots inside QEMU.

--- a/docs/test-reports/2025-09-29-boot-image-test.md
+++ b/docs/test-reports/2025-09-29-boot-image-test.md
@@ -1,0 +1,28 @@
+# Boot Image Test Report — 2025-09-29
+
+- **Tester:** Automated CI agent
+- **Command:** `pytest tests/test_boot_image_vm.py -vv`
+- **Environment:** Ubuntu 24.04 container; Nix 2.31.2 (single-user); QEMU 8.2.2; Python 3.11.12 with `pexpect` 4.9.0; virtualization without KVM acceleration.
+- **Result:** ❌ Failed — the VM boots but the pre-nixos storage provisioning service reports an error and the console only presents an automatic login as the unprivileged `nixos` user, so the tests hang waiting for a root shell.
+
+## Failure Details
+
+The ISO build now succeeds after enabling the `nix-command` and `flakes` experimental features. QEMU successfully boots the generated image, but the serial console shows the following warning immediately after login:
+
+```
+pre-nixos: Storage detection encountered an error; provisioning ran in plan-only mode.
+             Check 'journalctl -u pre-nixos' for details before continuing.
+```
+
+Because the boot sequence auto-logs into the `nixos` account, the integration harness never sees a `root@…#` prompt, so `pexpect` blocks until manual interruption. The captured console log ends with:
+
+```
+[nixos@nixos:~]$ root
+-bash: root: command not found
+```
+
+## Next Steps
+
+- Investigate the `pre-nixos` service failure (e.g., capture `journalctl -u pre-nixos` inside the VM) to understand why storage detection falls back to plan-only mode.
+- Adjust the integration fixture to tolerate the automatic `nixos` login (e.g., elevate to root via `sudo -i`) so that subsequent test assertions can execute even if auto-login is enabled.
+- Once storage provisioning is fixed, re-run `pytest tests/test_boot_image_vm.py` to validate both the storage and networking checks.


### PR DESCRIPTION
## Summary
- add a 2025-09-29 VM boot-image test report describing the pre-nixos storage detection failure and resulting hang in the integration harness

## Testing
- nix build .#bootImage --no-link
- pytest tests/test_boot_image_vm.py -vv *(hangs: boot image auto-logs into `nixos`, so the harness never reaches a root shell)*

------
https://chatgpt.com/codex/tasks/task_e_68d85a4d9a94832fab96ad939f574c8a