### PR TITLE
Ensure pre-nixos propagates util-linux for storage detection

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,8 @@
           src = ./.;
           pyproject = true;
           nativeBuildInputs = with pkgs.python3Packages; [ setuptools wheel ];
-          propagatedBuildInputs = with pkgs; [ gptfdisk mdadm lvm2 ethtool ];
+          propagatedBuildInputs =
+            with pkgs; [ gptfdisk mdadm lvm2 ethtool util-linux ];
           postPatch = pkgs.lib.optionalString (rootPub != null) ''
             cp ${rootPub} pre_nixos/root_key.pub
           '';

--- a/tests/test_flake_dependencies.py
+++ b/tests/test_flake_dependencies.py
@@ -1,0 +1,30 @@
+"""Tests for ensuring Nix flake packaging retains required dependencies."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def _extract_propagated_inputs() -> set[str]:
+    flake_text = Path("flake.nix").read_text(encoding="utf-8")
+    match = re.search(
+        r"propagatedBuildInputs\s*=\s*with pkgs;\s*\[(?P<body>[^\]]+)\];",
+        flake_text,
+        re.DOTALL,
+    )
+    if match is None:  # pragma: no cover - guard against structural changes
+        raise AssertionError("propagatedBuildInputs block not found in flake.nix")
+    body = match.group("body")
+    # The ``with pkgs;`` statement omits the ``pkgs.`` prefix from identifiers.
+    # Extract bare package names so the assertion remains robust even if the
+    # list is reformatted across multiple lines.
+    return set(re.findall(r"[A-Za-z0-9_-]+", body))
+
+
+def test_pre_nixos_runtime_dependencies_include_util_linux() -> None:
+    propagated = _extract_propagated_inputs()
+    # ``pre-nixos`` relies on util-linux tools such as ``findmnt`` for storage
+    # detection.  Ensure the package continues to propagate util-linux so the
+    # commands are available within the boot environment.
+    assert "util-linux" in propagated


### PR DESCRIPTION
## Summary
- add util-linux to the pre-nixos package so tools like findmnt are available in the boot environment
- add a regression test that verifies util-linux stays in the flake's propagated dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9e03259ac832f989eb1d834d15e42