### PR TITLE
Rename root logical volume to slash

### DIFF
--- a/automated-pre-nixos-design.md
+++ b/automated-pre-nixos-design.md
@@ -103,7 +103,7 @@ Provision bare-metal servers to a **known, repeatable disk + network baseline** 
 ### 7.4 LVM layout
 - **VGs:** `main`, `swap` (if present), `large` (if present). Additional SSD/HDD buckets are created as `main-1`, `large-1`, etc., and left without logical volumes.
 - **LVs:**
-  - `main/root` 20 GiB (ext4).
+  - `main/slash` 20 GiB (ext4).
   - `main/nix` 100–200 GiB.
   - `main/var` 20–50 GiB.
   - Swap: `swap/swap` on VG `swap`; fallback hierarchy: `large/swap` on VG `large`, else `main/swap` on VG `main` when capacity permits.

--- a/automated-pre-nixos-reqs.md
+++ b/automated-pre-nixos-reqs.md
@@ -20,7 +20,7 @@ The system must automate the hardware setup process on new servers prior to NixO
 
 - Detect all block devices present on the machine.
 - Classify them by type, size and function:
-  - SSD(s): designated for system/root volume.
+  - SSD(s): designated for the system `slash` volume.
   - For each group of (approximately) same-sized rotating disks:
     - If exactly two → use for swap on RAID-1.
     - If three or more → use for bulk storage on RAID-5 or RAID-6, depending on count.

--- a/docs/tui-mockups/detailed-mixed-tier.md
+++ b/docs/tui-mockups/detailed-mixed-tier.md
@@ -6,7 +6,7 @@ This mock illustrates the **detailed** density profile on an 110×34 terminal. A
 IP: 198.51.100.42 (lan)    View: Planned (detailed)           Focus: VG large          Legend: ■ SSD  ● HDD  ☐ EFI  ≡ RAID  ✱ mismatch
 
 Disk nvme0n1  ⟟ ─[☐ EFI]─[■ nvme0n1p2]─────────────┐
-                                                ├── md0 ≡ RAID1 (SSD) ── VG main ── root 40G (ext4)
+                                                ├── md0 ≡ RAID1 (SSD) ── VG main ── slash 40G (ext4)
 Disk nvme1n1  ⟟ ───────────────[■ nvme1n1p1]───────┘                         └─ nix 120G (ext4, dense)
                                                                              └─ var 30G (ext4)
 Disk nvme2n1  ⟟ ───────────────[■ (unused)]             (spare SSD bucket → VG main-1, unmounted)

--- a/docs/tui-mockups/existing-vs-planned.md
+++ b/docs/tui-mockups/existing-vs-planned.md
@@ -7,7 +7,7 @@ The following pair of frames demonstrates how the UI reuses the same focus ancho
 IP: 192.0.2.45 (lan)  View: Existing (compact)  Focus: LV data         Legend: ■ SSD  ● HDD  ☐ EFI  ≡ RAID  ░ dim=not in plan
 
 Disk nvme0n1  ⟟ ─[☐ EFI]─[■ nvme0n1p2]──────────┐
-                                              ├── md0 ≡ RAID1 (SSD) ── VG main ── root 35G
+                                              ├── md0 ≡ RAID1 (SSD) ── VG main ── slash 35G
 Disk nvme1n1  ⟟ ───────────────[■ nvme1n1p1]────┘                         └─ nix 90G (fragmented)
 
 Disk sda      ◎ ─[● sda1 data]──────────────┐
@@ -20,7 +20,7 @@ Disk sdb      ◎ ─[● sdb1 data]──────────────�
 IP: 192.0.2.45 (lan)  View: Planned (compact)   Focus: LV data         Legend: ■ SSD  ● HDD  ☐ EFI  ≡ RAID  ✱ mismatch
 
 Disk nvme0n1  ⟟ ─[☐ EFI]─[■ nvme0n1p2]──────────┐
-                                              ├── md0 ≡ RAID1 (SSD) ── VG main ── root 40G (ext4)
+                                              ├── md0 ≡ RAID1 (SSD) ── VG main ── slash 40G (ext4)
 Disk nvme1n1  ⟟ ───────────────[■ nvme1n1p1]────┘                         └─ nix 120G (ext4, dense)
 
 Disk sda      ◎ ─[● sda1 data]──────────────┐

--- a/pre_nixos/apply.py
+++ b/pre_nixos/apply.py
@@ -107,8 +107,8 @@ def apply_plan(plan: Dict[str, Any], dry_run: bool = False) -> List[str]:
         cmd = f"e2label {lv_path} {lv['name']}"
         commands.append(cmd)
         _run(cmd, execute)
-        mount_point = "/mnt" if lv["name"] == "root" else f"/mnt/{lv['name']}"
-        if lv["name"] != "root":
+        mount_point = "/mnt" if lv["name"] == "slash" else f"/mnt/{lv['name']}"
+        if lv["name"] != "slash":
             cmd = f"mkdir -p {mount_point}"
             commands.append(cmd)
             _run(cmd, execute)

--- a/pre_nixos/planner.py
+++ b/pre_nixos/planner.py
@@ -230,7 +230,7 @@ def plan_storage(
             add_array(name, arr["level"], devices, "hdd")
             add_vg("main", [name])
         swap_size = f"{ram_gb * 2 * 1024}M"
-        add_lv("root", "main", ROOT_LV_SIZE)
+        add_lv("slash", "main", ROOT_LV_SIZE)
         add_lv("swap", "main", swap_size)
         return plan
 
@@ -309,7 +309,7 @@ def plan_storage(
             None,
         )
     if any(vg["name"] == "main" for vg in plan["vgs"]):
-        add_lv("root", "main", ROOT_LV_SIZE)
+        add_lv("slash", "main", ROOT_LV_SIZE)
     if swap_vg is not None:
         add_lv("swap", swap_vg, swap_size)
     if any(vg["name"].startswith("large") for vg in plan["vgs"]):

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -16,7 +16,7 @@ def test_apply_plan_returns_commands() -> None:
     assert any(cmd.startswith("mdadm") for cmd in commands)
     assert any(cmd.startswith("pvcreate") for cmd in commands)
     assert any("vgcreate main" in cmd for cmd in commands)
-    assert f"lvcreate -n root main -L {ROOT_LV_SIZE}" in commands
+    assert f"lvcreate -n slash main -L {ROOT_LV_SIZE}" in commands
     assert any(cmd.startswith("mkswap") for cmd in commands)
     assert any(cmd.startswith("sgdisk") for cmd in commands)
     # only disks in the main VG should receive an EFI partition

--- a/tests/test_boot_image_vm.py
+++ b/tests/test_boot_image_vm.py
@@ -258,7 +258,7 @@ def test_boot_image_provisions_clean_disk(boot_image_vm: BootImageVM) -> None:
         "lvs --noheadings --separator '|' -o lv_name,vg_name", timeout=120
     )
     lv_pairs = {tuple(part.strip() for part in line.split("|")) for line in lv_output.splitlines() if line.strip()}
-    assert ("root", "main") in lv_pairs
+    assert ("slash", "main") in lv_pairs
 
 
 def test_boot_image_configures_network(boot_image_vm: BootImageVM) -> None:

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -17,9 +17,9 @@ def test_filesystem_commands_for_lvs() -> None:
 
     # mkfs.ext4 uses a 2 KiB bytes-per-inode ratio to avoid inode exhaustion
     # in the Nix store which contains many small files.
-    assert f"mkfs.ext4 -i 2048 /dev/main/root" in commands
-    assert f"e2label /dev/main/root root" in commands
-    assert f"mount -L root /mnt" in commands
+    assert f"mkfs.ext4 -i 2048 /dev/main/slash" in commands
+    assert f"e2label /dev/main/slash slash" in commands
+    assert f"mount -L slash /mnt" in commands
 
     assert f"mkfs.ext4 -i 2048 /dev/large/data" in commands
     assert f"e2label /dev/large/data data" in commands
@@ -30,7 +30,7 @@ def test_filesystem_commands_for_lvs() -> None:
     assert "mount -L EFI /mnt/boot" in commands
 
 
-def test_mount_points_created_for_non_root_lvs() -> None:
+def test_mount_points_created_for_non_slash_lvs() -> None:
     disks = [
         Disk(name="sda", size=1000, rotational=False),
         Disk(name="sdb", size=2000, rotational=True),
@@ -41,7 +41,7 @@ def test_mount_points_created_for_non_root_lvs() -> None:
     commands = apply_plan(plan)
 
     for lv in plan["lvs"]:
-        if lv["name"] in {"root", "swap"}:
+        if lv["name"] in {"slash", "swap"}:
             continue
         mount_point = f"/mnt/{lv['name']}"
         mkdir_cmd = f"mkdir -p {mount_point}"

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -60,7 +60,7 @@ def sample_plan() -> dict:
             {"name": "bulk", "devices": ["sda2"]},
         ],
         "lvs": [
-            {"name": "root", "vg": "main", "size": "50G"},
+            {"name": "slash", "vg": "main", "size": "50G"},
             {"name": "home", "vg": "main", "size": "100G"},
             {"name": "data", "vg": "bulk", "size": "1T"},
         ],
@@ -92,7 +92,7 @@ def test_tui_exposes_run():
 def test_plan_renderer_prefers_detailed_profile(renderer):
     render = renderer.render(100, 20, None, "auto", expanded=())
     assert render.profile == "detailed"
-    assert render.focusables[0] == ("lv", "main", "root")
+    assert render.focusables[0] == ("lv", "main", "slash")
     assert render.lines[0].startswith("Disk nvme0n1")
 
 
@@ -107,7 +107,7 @@ def test_minimal_layout_expands_focus(renderer):
     focus = ("vg", "main", None)
     render = renderer.render(40, 10, focus, "minimal", expanded={focus})
     assert any("⇒ VG main" in line for line in render.lines)
-    assert any("root 50G" in line for line in render.lines)
+    assert any("slash 50G" in line for line in render.lines)
     assert focus in render.focusables
 
 


### PR DESCRIPTION
## Summary
- update the storage planner and applier to create the root filesystem logical volume as `slash`
- adjust related tests and expectations to reference the new logical volume name

## Testing
- pytest tests/test_plan_storage.py tests/test_filesystems.py tests/test_tui.py


------
https://chatgpt.com/codex/tasks/task_e_68da86dab108832f9329fd983c4701dd