### PR TITLE
Implement Disko-based storage planner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# NixOS Boot Image Planner
+
+This repository experiments with a simple planner that turns a high-level storage
+plan into a [Disko](https://github.com/nix-community/disko) configuration and
+invokes Disko to prepare target disks.
+
+See [docs/design.md](docs/design.md) for an in-depth explanation of the storage
+planning workflow.

--- a/bootimage/__init__.py
+++ b/bootimage/__init__.py
@@ -1,0 +1,9 @@
+"""Boot image planner package."""
+
+from .planner import DiskoPlan, DiskoExecutor, generate_disko_plan
+
+__all__ = [
+    "DiskoPlan",
+    "DiskoExecutor",
+    "generate_disko_plan",
+]

--- a/bootimage/planner.py
+++ b/bootimage/planner.py
@@ -1,0 +1,219 @@
+"""Planner that emits Disko configuration and applies it via the Disko CLI."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass, field
+import json
+import os
+import subprocess
+import tempfile
+from typing import Any, Callable, Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+
+def _ensure(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _normalise_disk_name(device: str, fallback: str = "disk") -> str:
+    token = device.strip().replace("/", "-").strip("-")
+    return token or fallback
+
+
+@dataclass
+class DiskoPlan:
+    """Normalised plan ready to be rendered and executed by Disko."""
+
+    config: Mapping[str, Any]
+    mode: str = "destroy,format,mount"
+    flags: List[str] = field(default_factory=list)
+
+    def render(self) -> str:
+        """Render the configuration to Nix syntax."""
+
+        return _to_nix(self.config) + "\n"
+
+    def command(self, *, nix_bin: str, disko_ref: str, config_path: str) -> List[str]:
+        """Assemble the Disko invocation command."""
+
+        cmd = [
+            nix_bin,
+            "--experimental-features",
+            "nix-command flakes",
+            "run",
+            disko_ref,
+            "--",
+            "--mode",
+            self.mode,
+        ]
+        cmd.extend(self.flags)
+        cmd.append(config_path)
+        return cmd
+
+
+def generate_disko_plan(plan: Mapping[str, Any]) -> DiskoPlan:
+    """Generate a :class:`DiskoPlan` from a high-level plan mapping."""
+
+    disks: Iterable[Mapping[str, Any]] = plan.get("disks", [])  # type: ignore[assignment]
+    _ensure(disks, "plan requires at least one disk entry")
+
+    devices: MutableMapping[str, Any] = OrderedDict()
+
+    for disk in disks:
+        device = disk.get("device")
+        _ensure(isinstance(device, str) and device, "disk entry missing 'device'")
+        name = disk.get("name") or _normalise_disk_name(device)
+        partitions = disk.get("partitions", [])
+        _ensure(partitions, f"disk '{name}' requires at least one partition")
+
+        disk_entry: Dict[str, Any] = OrderedDict()
+        disk_entry["device"] = device
+        disk_entry["type"] = "disk"
+
+        content: Dict[str, Any] = OrderedDict()
+        content["type"] = disk.get("scheme", "gpt")
+        content["partitions"] = _build_partitions(partitions)
+        disk_entry["content"] = content
+
+        devices[name] = disk_entry
+
+    config: MutableMapping[str, Any] = OrderedDict()
+    config["disko.devices"] = OrderedDict([("disk", devices)])
+
+    mode = _normalise_mode(plan.get("mode"))
+    raw_flags = plan.get("disko_flags", [])
+    if isinstance(raw_flags, str):
+        raw_flags = [raw_flags]
+    flags = list(raw_flags)
+    for flag in flags:
+        _ensure(isinstance(flag, str), "disko_flags entries must be strings")
+
+    return DiskoPlan(config=config, mode=mode, flags=flags)
+
+
+def _build_partitions(partitions: Iterable[Mapping[str, Any]]) -> Mapping[str, Any]:
+    result: MutableMapping[str, Any] = OrderedDict()
+    for partition in partitions:
+        name = partition.get("name")
+        _ensure(isinstance(name, str) and name, "partition missing 'name'")
+        entry: Dict[str, Any] = OrderedDict()
+
+        for key in ("size", "type", "start", "end", "priority", "label"):
+            if key in partition:
+                entry[key] = partition[key]
+
+        if "content" in partition:
+            entry["content"] = partition["content"]
+        else:
+            filesystem = partition.get("filesystem")
+            _ensure(
+                isinstance(filesystem, Mapping),
+                f"partition '{name}' missing filesystem definition",
+            )
+            fmt = filesystem.get("format")
+            _ensure(isinstance(fmt, str) and fmt, f"partition '{name}' missing filesystem format")
+            fs_entry: Dict[str, Any] = OrderedDict()
+            fs_entry["type"] = "filesystem"
+            fs_entry["format"] = fmt
+            for key, value in filesystem.items():
+                if key == "format":
+                    continue
+                fs_entry[key] = value
+            entry["content"] = fs_entry
+
+        result[name] = entry
+    return result
+
+
+def _normalise_mode(value: Optional[Any]) -> str:
+    if value is None:
+        return "destroy,format,mount"
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Iterable):
+        parts: List[str] = []
+        for mode in value:
+            _ensure(isinstance(mode, str), "mode entries must be strings")
+            parts.append(mode)
+        _ensure(parts, "mode iterable cannot be empty")
+        return ",".join(parts)
+    raise ValueError("mode must be a string or iterable of strings")
+
+
+def _to_nix(value: Any, indent: int = 0) -> str:
+    pad = " " * indent
+    if isinstance(value, Mapping):
+        items = []
+        items.append("{")
+        for key, val in value.items():
+            rendered = _to_nix(val, indent + 2)
+            if "\n" in rendered:
+                rendered = "\n".join(" " * (indent + 2) + line for line in rendered.splitlines())
+                items.append(f"{' ' * (indent + 2)}{key} =\n{rendered};")
+            else:
+                items.append(f"{' ' * (indent + 2)}{key} = {rendered};")
+        items.append(f"{pad}" + "}")
+        return "\n".join(items)
+    if isinstance(value, list):
+        if not value:
+            return "[ ]"
+        inner = [
+            " " * (indent + 2) + _to_nix(item, indent + 2)
+            for item in value
+        ]
+        return "[\n" + "\n".join(inner) + f"\n{pad}]"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if value is None:
+        return "null"
+    if isinstance(value, (int, float)):
+        return json.dumps(value)
+    if isinstance(value, str):
+        return json.dumps(value)
+    raise TypeError(f"unsupported type for Nix serialisation: {type(value)!r}")
+
+
+Runner = Callable[[List[str]], None]
+
+
+class DiskoExecutor:
+    """Apply Disko plans by invoking the Disko CLI through nix."""
+
+    def __init__(
+        self,
+        *,
+        runner: Optional[Runner] = None,
+        nix_bin: str = "nix",
+        disko_ref: str = "github:nix-community/disko/latest",
+    ) -> None:
+        self._runner = runner or self._default_runner
+        self._nix_bin = nix_bin
+        self._disko_ref = disko_ref
+
+    @staticmethod
+    def _default_runner(cmd: List[str]) -> None:
+        subprocess.run(cmd, check=True)
+
+    def apply(self, plan: Mapping[str, Any], *, workdir: Optional[str] = None) -> None:
+        disko_plan = generate_disko_plan(plan)
+        rendered = disko_plan.render()
+        fd: Optional[tempfile.NamedTemporaryFile] = None
+        path: Optional[str] = None
+        try:
+            fd = tempfile.NamedTemporaryFile("w", suffix=".nix", delete=False, dir=workdir)
+            fd.write(rendered)
+            fd.flush()
+            path = fd.name
+        finally:
+            if fd is not None:
+                fd.close()
+        assert path is not None
+        try:
+            cmd = disko_plan.command(nix_bin=self._nix_bin, disko_ref=self._disko_ref, config_path=path)
+            self._runner(cmd)
+        finally:
+            try:
+                os.remove(path)
+            except OSError:
+                pass

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,120 @@
+# Storage Planning and Provisioning Design
+
+## Background
+
+The boot image builder needs to take a high-level description of how the
+installation media should partition, format, and mount the target disks. The
+previous implementation translated the plan directly into imperative shell
+commands (`sgdisk`, `mkfs`, `mount`, etc.). That direct approach made it hard to
+support complex layouts, reason about idempotence, or share logic with other
+NixOS installers.
+
+Disko already provides a declarative DSL for describing storage topologies and a
+robust implementation for applying them. By generating a Disko configuration and
+invoking Disko itself, we can reuse that logic instead of reimplementing it.
+
+## Goals
+
+* Accept the existing high-level plan schema without change.
+* Translate the plan into a Disko configuration that mirrors the desired disk
+  topology.
+* Invoke Disko to materialise the partition tables, format filesystems, and
+  mount everything.
+* Keep the Disko invocation isolated so it can be unit tested by swapping out
+  the command runner.
+
+## Architecture
+
+```
+┌────────────┐      ┌─────────────────────┐      ┌────────────┐
+│  Planner   │ ---> │ Disko configuration │ ---> │ Disko CLI │
+└────────────┘      └─────────────────────┘      └────────────┘
+```
+
+1. **Planner** – converts the domain plan into a normalised representation of
+   the disk topology. The core responsibility is to expand convenient shortcut
+   fields (for example, `filesystem.format`) into the structure that Disko
+   expects under `disko.devices`.
+2. **Disko configuration** – serialised from the normalised representation into
+   a standalone `.nix` file containing the `disko.devices` attribute set. The
+   serialisation is deterministic so unit tests can assert on the generated
+   output.
+3. **Disko CLI** – we run Disko via
+   `nix run github:nix-community/disko/latest -- …`, passing the generated file
+   and mode flags (e.g. `destroy,format,mount`). The executor coordinates the
+   temporary file lifecycle and command invocation.
+
+## Planner Output
+
+The planner returns a `DiskoPlan` object that contains:
+
+* `config`: Ordered mapping that becomes the `disko.devices` attribute set.
+* `mode`: Comma-separated Disko modes (defaults to `destroy,format,mount`).
+* `flags`: Additional CLI flags to append after `--mode` (defaults to empty).
+
+Every disk entry is normalised to the following shape:
+
+```nix
+{
+  disko.devices = {
+    disk = {
+      <disk-name> = {
+        device = "/dev/<device>";
+        type = "disk";
+        content = {
+          type = "gpt"; # overridable via plan["scheme"]
+          partitions = {
+            <partition-name> = {
+              size = "<size>";
+              # optional: type, start, end, etc.
+              content = {
+                type = "filesystem";
+                format = "ext4"; # or the requested format
+                mountpoint = "/";
+                mountOptions = [ "subvol=@" ];
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}
+```
+
+If the plan provides an explicit `content` attribute for a partition (for
+example, for LUKS or LVM), it is passed through verbatim. Otherwise the planner
+builds a `filesystem` entry from the shortcut fields.
+
+## Disko Execution Flow
+
+1. The executor calls `generate_disko_plan(plan)` to obtain a `DiskoPlan`.
+2. The plan is rendered to a temporary `.nix` file through `DiskoPlan.render()`.
+3. We assemble the Disko command:
+   ```
+   nix --experimental-features "nix-command flakes" \
+     run github:nix-community/disko/latest -- \
+     --mode destroy,format,mount <optional flags…> /tmp/disko-plan-XXXX.nix
+   ```
+4. The executor runs the command using a pluggable runner (defaulting to
+   `subprocess.run(cmd, check=True)`).
+5. The temporary file is deleted after Disko exits (successfully or otherwise).
+
+## Error Handling
+
+* The planner raises `ValueError` when required fields (e.g. `device` or
+  `partitions`) are missing.
+* The executor lets `subprocess.CalledProcessError` propagate so callers can
+  surface Disko failures to the user.
+* Temporary files are removed in a `finally` block to avoid leaking secrets or
+  stale configurations on disk.
+
+## Testing Strategy
+
+* Unit tests cover the planner transformation so complex storage layouts can be
+  validated without touching real disks.
+* Executor tests inject a fake runner to capture the generated Disko command and
+  inspect the temporary file contents.
+
+This design keeps the planner focused on pure data transformation, while Disko
+handles the imperative disk operations.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,133 @@
+from pathlib import Path
+
+import pytest
+
+from bootimage.planner import DiskoExecutor, generate_disko_plan
+
+
+@pytest.fixture
+def sample_plan():
+    return {
+        "disks": [
+            {
+                "name": "os",
+                "device": "/dev/sda",
+                "scheme": "gpt",
+                "partitions": [
+                    {
+                        "name": "ESP",
+                        "size": "512MiB",
+                        "type": "EF00",
+                        "filesystem": {
+                            "format": "vfat",
+                            "mountpoint": "/boot",
+                            "mountOptions": ["umask=0077"],
+                        },
+                    },
+                    {
+                        "name": "root",
+                        "size": "100%",
+                        "filesystem": {
+                            "format": "ext4",
+                            "mountpoint": "/",
+                        },
+                    },
+                ],
+            }
+        ],
+        "mode": ["destroy", "format", "mount"],
+        "disko_flags": ["--yes"],
+    }
+
+
+def test_generate_disko_plan_structure(sample_plan):
+    plan = generate_disko_plan(sample_plan)
+    disk_config = plan.config["disko.devices"]["disk"]["os"]
+    assert disk_config["device"] == "/dev/sda"
+    assert disk_config["content"]["type"] == "gpt"
+    partitions = disk_config["content"]["partitions"]
+    assert set(partitions.keys()) == {"ESP", "root"}
+    assert partitions["ESP"]["content"]["format"] == "vfat"
+    assert plan.mode == "destroy,format,mount"
+    assert plan.flags == ["--yes"]
+
+
+def test_rendered_nix_contains_expected_sections(sample_plan):
+    plan = generate_disko_plan(sample_plan)
+    nix_text = plan.render()
+    assert "disko.devices" in nix_text
+    assert "mountOptions" in nix_text
+    assert "\"/boot\"" in nix_text
+
+
+def test_executor_invokes_runner(tmp_path, sample_plan):
+    commands = []
+    contents = {}
+
+    def fake_runner(cmd):
+        commands.append(cmd)
+        path = Path(cmd[-1])
+        contents["path"] = path
+        contents["text"] = path.read_text()
+
+    executor = DiskoExecutor(runner=fake_runner)
+    executor.apply(sample_plan, workdir=tmp_path)
+
+    assert len(commands) == 1
+    cmd = commands[0]
+    assert cmd[0] == "nix"
+    assert "--mode" in cmd
+    assert cmd[-1].startswith(str(tmp_path))
+    assert "disko.devices" in contents["text"]
+    assert not contents["path"].exists()
+
+
+def test_invalid_plan_missing_disk():
+    with pytest.raises(ValueError):
+        generate_disko_plan({})
+
+
+def test_invalid_partition_missing_fs():
+    plan = {
+        "disks": [
+            {
+                "device": "/dev/sda",
+                "partitions": [
+                    {
+                        "name": "root",
+                        "size": "100%",
+                    }
+                ],
+            }
+        ]
+    }
+    with pytest.raises(ValueError):
+        generate_disko_plan(plan)
+
+
+def test_serialises_boolean_and_numbers():
+    plan = {
+        "disks": [
+            {
+                "device": "/dev/sdb",
+                "partitions": [
+                    {
+                        "name": "data",
+                        "size": "10G",
+                        "filesystem": {
+                            "format": "btrfs",
+                            "mountpoint": "/data",
+                            "mountOptions": ["compress=zstd", True],
+                            "extra": {"quota": False, "level": 2},
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+
+    plan_obj = generate_disko_plan(plan)
+    rendered = plan_obj.render()
+    assert "true" in rendered
+    assert "false" in rendered
+    assert "level = 2;" in rendered


### PR DESCRIPTION
## Summary
- document the storage planning flow and the switch to generating Disko configuration
- add a planner module that emits Disko-ready plans and executes them through the Disko CLI
- cover the planner and executor with pytest unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68da8d7c99b0832fbefc84d7004220e8