### PR TITLE
Refine pre-nixos system package list

### DIFF
--- a/modules/pre-nixos.nix
+++ b/modules/pre-nixos.nix
@@ -7,11 +7,12 @@ let
   preNixosExecEnv = { PRE_NIXOS_EXEC = "1"; };
   preNixosLoginNotice = builtins.readFile ./pre-nixos/login-notice.sh;
   preNixosServiceScript = import ./pre-nixos/service-script.nix { inherit pkgs; };
+  utilLinux = lib.getAttrFromPath [ "util-linux" ] pkgs;
 in {
   options.services.pre-nixos.enable = lib.mkEnableOption "run pre-nixos planning tool";
 
   config = lib.mkIf cfg.enable {
-    environment.systemPackages = [ pkgs.pre-nixos pkgs.util-linux pkgs.minicom ];
+    environment.systemPackages = with pkgs; [ pre-nixos utilLinux minicom ];
     environment.sessionVariables = preNixosExecEnv;
     environment.interactiveShellInit = preNixosLoginNotice;
     boot.kernelParams = [ "console=ttyS0,115200n8" "console=tty0" ];

--- a/tests/test_pre_nixos_module.py
+++ b/tests/test_pre_nixos_module.py
@@ -22,7 +22,7 @@ def _extract_service_path_packages() -> set[str]:
     block = module_text[start:end]
     match = re.search(r"path\s*=\s*with pkgs;\s*\[(?P<body>[^\]]+)\];", block, re.DOTALL)
     if match is None:
-        raise AssertionError("systemd.services.pre-nixos.path definition missing")
+        raise AssertionError("systemd.services.pre-nixos path definition missing")
 
     body = match.group("body")
     tokens = {


### PR DESCRIPTION
## Summary
- fetch the hyphenated util-linux derivation via lib.getAttrFromPath for reuse in the module
- use a with pkgs scope so the systemPackages list no longer repeats the pkgs prefix

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db3c9538a8832fa0218a73d01e908c