### PR TITLE
Ensure boot image bundles disko and expand testing

### DIFF
--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -1,0 +1,64 @@
+# Test Plan
+
+This document captures the end-to-end validation strategy for the Pre-NixOS
+boot image and CLI tooling.  It enumerates prerequisites, outlines how to
+prepare the environment, and lists the mandatory test suites.
+
+## 1. Toolchain Installation
+
+1. Install the Nix package manager following the official instructions at
+   <https://nixos.org/download>.
+2. Enter the dedicated development shell that provides all runtime test
+   dependencies (Python, pytest, pexpect, QEMU, and the Nix CLI):
+
+   ```bash
+   nix develop .#bootImageTest
+   ```
+
+   The `bootImageTest` shell is defined in `flake.nix` and guarantees a
+   consistent toolchain across developer laptops and CI agents.
+3. Ensure network access to the public Nix binary cache and source mirrors:
+   `https://cache.nixos.org/` and `https://ftpmirror.gnu.org/`.  These hosts are
+   required for building the boot image.
+
+## 2. Python Unit Tests
+
+Run the fast unit-test suite directly from the repository root:
+
+```bash
+pytest
+```
+
+This exercises the inventory, planner, network configuration, TUI rendering,
+CLI behaviour, and packaging invariants.  The suite must be green before
+running slower integration scenarios.
+
+## 3. Boot Image Integration Tests
+
+The boot image tests build the ISO with Nix, boot it inside QEMU, and validate
+end-to-end storage provisioning and DHCP configuration.
+
+```bash
+pytest tests/test_boot_image_vm.py
+```
+
+These tests require hardware virtualisation support and may take several
+minutes.  They are non-optional: failures or skips indicate inadequate testing.
+Inspect the generated serial console log (stored under
+`/tmp/pytest-of-*/boot-image-logs/serial.log`) when debugging regressions.
+
+## 4. Manual Smoke Tests (optional but recommended)
+
+For additional assurance before releases:
+
+1. Boot the generated ISO on representative bare-metal hardware.
+2. Confirm the `pre-nixos` CLI detects disks, produces a plan, applies it with
+   `disko`, and that the resulting layout matches expectations.
+3. Verify SSH access using the embedded public key and ensure the primary NIC is
+   renamed to `lan` with an IPv4 lease.
+
+## 5. Reporting
+
+Record the outcome of each run (command, date, tester, result, and any
+observations) in `docs/test-reports/`.  Link CI job URLs where applicable so the
+history of test executions remains auditable.

--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
           nativeBuildInputs = with pkgs.python3Packages; [ setuptools wheel ];
           propagatedBuildInputs =
             pkgs.lib.attrVals
-              [ "gptfdisk" "mdadm" "lvm2" "ethtool" "util-linux" ]
+              [ "disko" "gptfdisk" "mdadm" "lvm2" "ethtool" "util-linux" ]
               pkgs;
           postPatch = pkgs.lib.optionalString (rootPub != null) ''
             cp ${rootPub} pre_nixos/root_key.pub
@@ -93,7 +93,7 @@
         checks = {
           pre-nixos-propagates-required-tools =
             let
-              requiredTools = [ "gptfdisk" "mdadm" "lvm2" "ethtool" "util-linux" ];
+              requiredTools = [ "disko" "gptfdisk" "mdadm" "lvm2" "ethtool" "util-linux" ];
               propagatedNames =
                 builtins.map
                   (drv:
@@ -110,8 +110,19 @@
               touch $out
             '';
         };
-        devShells.default = pkgs.mkShell {
-          buildInputs = [ pkgs.python3 pkgs.python3Packages.pytest ];
+        devShells = {
+          default = pkgs.mkShell {
+            buildInputs = [ pkgs.python3 pkgs.python3Packages.pytest ];
+          };
+          bootImageTest = pkgs.mkShell {
+            buildInputs = [
+              pkgs.python3
+              pkgs.python3Packages.pytest
+              pkgs.python3Packages.pexpect
+              pkgs.qemu
+              pkgs.nix
+            ];
+          };
         };
       }) // {
       nixosModules.pre-nixos = preNixosModule;

--- a/modules/pre-nixos.nix
+++ b/modules/pre-nixos.nix
@@ -11,7 +11,7 @@ in {
   options.services.pre-nixos.enable = lib.mkEnableOption "run pre-nixos planning tool";
 
   config = lib.mkIf cfg.enable {
-    environment.systemPackages = [ pkgs.pre-nixos pkgs.util-linux pkgs.minicom ];
+    environment.systemPackages = [ pkgs.pre-nixos pkgs.disko pkgs.util-linux pkgs.minicom ];
     environment.sessionVariables = preNixosExecEnv;
     environment.interactiveShellInit = preNixosLoginNotice;
     boot.kernelParams = [ "console=ttyS0,115200n8" "console=tty0" ];
@@ -28,6 +28,7 @@ in {
       environment = preNixosExecEnv;
       path = with pkgs; [
         coreutils
+        disko
         dosfstools
         e2fsprogs
         ethtool

--- a/tests/test_boot_image_vm.py
+++ b/tests/test_boot_image_vm.py
@@ -243,7 +243,7 @@ def boot_image_vm(
 
 
 def test_boot_image_provisions_clean_disk(boot_image_vm: BootImageVM) -> None:
-    boot_image_vm.assert_commands_available("findmnt", "lsblk", "wipefs")
+    boot_image_vm.assert_commands_available("disko", "findmnt", "lsblk", "wipefs")
     status = boot_image_vm.wait_for_storage_status()
     assert status["STATE"] == "applied"
     assert status["DETAIL"] == "auto-applied"

--- a/tests/test_flake_dependencies.py
+++ b/tests/test_flake_dependencies.py
@@ -36,6 +36,7 @@ def test_pre_nixos_runtime_dependencies_include_required_tools() -> None:
     propagated = _extract_propagated_inputs()
     required_tools = {
         # Storage partitioning utilities
+        "disko",
         "gptfdisk",
         "mdadm",
         "lvm2",

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -12,4 +12,10 @@ def test_import_package() -> None:
 
 
 def test_import_modules() -> None:
-    from pre_nixos import inventory, planner, apply, network  # noqa: F401
+    from pre_nixos import apply, inventory, network, planner  # noqa: F401
+
+
+def test_import_cli_entrypoint() -> None:
+    """Ensure the CLI module imports without missing dependencies."""
+
+    __import__("pre_nixos.pre_nixos")

--- a/tests/test_pre_nixos_module.py
+++ b/tests/test_pre_nixos_module.py
@@ -37,6 +37,7 @@ def test_service_path_includes_runtime_utilities() -> None:
     packages = _extract_service_path_packages()
     required = {
         "coreutils",
+        "disko",
         "dosfstools",
         "e2fsprogs",
         "ethtool",


### PR DESCRIPTION
## Summary
- include the disko CLI in the boot image service path and propagated build inputs so storage application works during provisioning
- tighten the test suites to check for the CLI module import and to require disko for both the VM integration tests and the flake packaging
- add a dedicated boot-image test development shell and document a comprehensive end-to-end test plan

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de81b33df8832fa5f561e588857cf3