### PR TITLE
Add Codex automation scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
 *.pyc
+.venv/
 pre_nixos/root_key
 pre_nixos/root_key.pub

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -6,9 +6,21 @@ prepare the environment, and lists the mandatory test suites.
 
 ## 1. Toolchain Installation
 
-1. Install the Nix package manager following the official instructions at
-   <https://nixos.org/download>.
-2. Enter the dedicated development shell that provides all runtime test
+1. Run the automation helper from the repository root to provision the tooling
+   used by the Codex environment:
+
+   ```bash
+   ./scripts/codex-setup.sh
+   ```
+
+   The script installs required APT packages, provisions the Python virtual
+   environment in `.venv`, installs `pytest` and `pexpect`, and bootstraps the
+   single-user Nix CLI. Subsequent container starts execute
+   `scripts/codex-maintenance.sh`, which refreshes Python dependencies and keeps
+   the Nix profile sourced automatically.
+2. Install the Nix package manager following the official instructions at
+   <https://nixos.org/download> if the automated setup is skipped or fails.
+3. Enter the dedicated development shell that provides all runtime test
    dependencies (Python, pytest, pexpect, QEMU, and the Nix CLI):
 
    ```bash
@@ -17,7 +29,7 @@ prepare the environment, and lists the mandatory test suites.
 
    The `bootImageTest` shell is defined in `flake.nix` and guarantees a
    consistent toolchain across developer laptops and CI agents.
-3. Ensure network access to the public Nix binary cache and source mirrors:
+4. Ensure network access to the public Nix binary cache and source mirrors:
    `https://cache.nixos.org/` and `https://ftpmirror.gnu.org/`.  These hosts are
    required for building the boot image.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest>=8.0
+pexpect>=4.9

--- a/scripts/codex-maintenance.sh
+++ b/scripts/codex-maintenance.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_PREFIX="[${SCRIPT_NAME}]"
+
+log() {
+  printf '%s %s\n' "${LOG_PREFIX}" "$*"
+}
+
+authorise_nix_profile() {
+  local -r nix_profile="$HOME/.nix-profile/etc/profile.d/nix.sh"
+  local -r shell_profile="$HOME/.profile"
+
+  if [[ ! -f "${nix_profile}" ]]; then
+    log "Nix profile script not found; skipping shell integration."
+    return 0
+  fi
+
+  if [[ -f "${shell_profile}" ]] && grep -Fqs 'nix.sh' "${shell_profile}"; then
+    log "Shell profile already sources nix.sh"
+    return 0
+  fi
+
+  log "Adding Nix profile sourcing to ${shell_profile}"
+  {
+    printf '\n# Added by %s on %s\n' "${SCRIPT_NAME}" "$(date --iso-8601=seconds)"
+    printf 'export USER=${USER:-$(id -un)}\n'
+    printf '. "$HOME/.nix-profile/etc/profile.d/nix.sh"\n'
+  } >> "${shell_profile}"
+}
+
+update_python_dependencies() {
+  local -r venv_path="${REPO_ROOT}/.venv"
+
+  if [[ ! -d "${venv_path}" ]]; then
+    log "Virtual environment missing; running setup script without Nix install."
+    "${REPO_ROOT}/scripts/codex-setup.sh" --skip-nix
+    return 0
+  fi
+
+  if [[ ! -f "${REPO_ROOT}/requirements-dev.txt" ]]; then
+    log "requirements-dev.txt not present; nothing to update."
+    return 0
+  fi
+
+  log "Upgrading Python developer dependencies"
+  "${venv_path}/bin/pip" install --upgrade -r "${REPO_ROOT}/requirements-dev.txt"
+}
+
+main() {
+  authorise_nix_profile
+  update_python_dependencies
+  log "Maintenance tasks completed."
+}
+
+main "$@"

--- a/scripts/codex-setup.sh
+++ b/scripts/codex-setup.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_PREFIX="[${SCRIPT_NAME}]"
+
+usage() {
+  cat <<USAGE
+Usage: ${SCRIPT_NAME} [--skip-nix]
+
+Provision development dependencies for the Pre-NixOS project. The script is
+idempotent and safe to run multiple times.
+
+Options:
+  --skip-nix   Do not attempt to install the Nix package manager. Useful when
+               running in environments where Nix is preinstalled or managed
+               separately.
+USAGE
+}
+
+log() {
+  printf '%s %s\n' "${LOG_PREFIX}" "$*"
+}
+
+install_apt_packages() {
+  if ! command -v apt-get >/dev/null 2>&1; then
+    log "apt-get not available; skipping APT package installation."
+    return 0
+  fi
+
+  local -r packages=(
+    ca-certificates
+    curl
+    gnupg
+    xz-utils
+    python3
+    python3-venv
+    python3-pip
+    python3-dev
+    build-essential
+    qemu-system-x86
+    qemu-utils
+  )
+
+  log "Updating APT package index..."
+  apt-get update
+
+  log "Installing required APT packages: ${packages[*]}"
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "${packages[@]}"
+}
+
+install_nix() {
+  if command -v nix >/dev/null 2>&1; then
+    log "Nix already installed; skipping."
+    return 0
+  fi
+
+  if [[ "${SKIP_NIX:-0}" == "1" ]]; then
+    log "Skipping Nix installation because --skip-nix was provided."
+    return 0
+  fi
+
+  log "Installing Nix (single-user mode)..."
+  local installer
+  installer="$(mktemp -t nix-installer-XXXXXX.sh)"
+
+  if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+    if ! getent group nixbld >/dev/null 2>&1; then
+      log "Creating system group 'nixbld' for single-user root installation"
+      groupadd --system nixbld
+    fi
+
+    if [[ ! -d /var/empty ]]; then
+      mkdir -p /var/empty
+      chmod 755 /var/empty
+    fi
+
+    for idx in $(seq 1 10); do
+      local user="nixbld${idx}"
+      if ! id -u "${user}" >/dev/null 2>&1; then
+        log "Creating build user ${user}"
+        useradd --system --home-dir /var/empty --no-create-home --shell /usr/sbin/nologin "${user}"
+      fi
+      usermod -a -G nixbld "${user}"
+    done
+  fi
+
+  curl -fsSL -o "${installer}" https://nixos.org/nix/install
+  chmod +x "${installer}"
+  if ! "${installer}" --no-daemon; then
+    rm -f "${installer}"
+    log "Nix installer failed." >&2
+    exit 1
+  fi
+
+  rm -f "${installer}"
+
+  log "Nix installation completed. Ensure future shells source \"$HOME/.nix-profile/etc/profile.d/nix.sh\"."
+}
+
+create_python_venv() {
+  local -r venv_path="${REPO_ROOT}/.venv"
+
+  if [[ ! -d "${venv_path}" ]]; then
+    log "Creating Python virtual environment at ${venv_path}"
+    python3 -m venv "${venv_path}"
+  else
+    log "Virtual environment already exists at ${venv_path}"
+  fi
+
+  log "Upgrading pip inside the virtual environment"
+  "${venv_path}/bin/python" -m pip install --upgrade pip
+
+  if [[ -f "${REPO_ROOT}/requirements-dev.txt" ]]; then
+    log "Installing Python developer requirements"
+    "${venv_path}/bin/pip" install --upgrade -r "${REPO_ROOT}/requirements-dev.txt"
+  else
+    log "requirements-dev.txt not found; skipping Python dependency installation."
+  fi
+}
+
+configure_nix_features() {
+  if [[ -z "${HOME:-}" ]]; then
+    log "HOME is not set; skipping Nix configuration"
+    return 0
+  fi
+
+  local -r conf_dir="${HOME}/.config/nix"
+  local -r conf_file="${conf_dir}/nix.conf"
+  mkdir -p "${conf_dir}"
+
+  local desired="experimental-features = nix-command flakes"
+
+  if [[ -f "${conf_file}" ]]; then
+    if grep -Eq '^experimental-features = .*(nix-command).*(flakes)' "${conf_file}"; then
+      log "Nix experimental features already enabled in ${conf_file}"
+      return 0
+    fi
+
+    if grep -Eq '^experimental-features' "${conf_file}"; then
+      log "Updating experimental features entry in ${conf_file}"
+      sed -i 's/^experimental-features.*/experimental-features = nix-command flakes/' "${conf_file}"
+    else
+      log "Appending experimental features entry to ${conf_file}"
+      printf '%s\n' "${desired}" >> "${conf_file}"
+    fi
+  else
+    log "Creating ${conf_file} with required experimental features"
+    printf '%s\n' "${desired}" > "${conf_file}"
+  fi
+}
+
+main() {
+  local SKIP_NIX=0
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --skip-nix)
+        SKIP_NIX=1
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        printf 'Unknown option: %s\n\n' "$1" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  install_apt_packages
+  SKIP_NIX="${SKIP_NIX}" install_nix
+  create_python_venv
+  configure_nix_features
+
+  log "Setup completed successfully."
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add codex-setup and codex-maintenance helpers to provision apt packages, a Python virtualenv, and single-user Nix with experimental features enabled
- introduce requirements-dev.txt and ignore the local virtual environment directory
- document the automation entrypoints in the toolchain installation section of the test plan

## Testing
- `pytest`
- `pytest tests/test_boot_image_vm.py -k "" --maxfail=1 -vv` *(fails: VM login times out when the boot image drops to the nixos user prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68df1c31b724832f8d6f0f04498a2f92