### PR TITLE
Ensure VM SSH helper restricts identities

### DIFF
--- a/tests/test_boot_image_vm.py
+++ b/tests/test_boot_image_vm.py
@@ -349,6 +349,8 @@ class BootImageVM:
             "-i",
             str(private_key),
             "-o",
+            "IdentitiesOnly=yes",
+            "-o",
             "BatchMode=yes",
             "-o",
             "StrictHostKeyChecking=no",


### PR DESCRIPTION
## Summary
- force the VM test harness SSH helper to pass `IdentitiesOnly=yes` so only the generated key is offered

## Testing
- `pytest tests/test_boot_image_vm.py -vv` *(fails: interrupted after hanging while provisioning the VM)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b4277ac0832f9dfc4cb8d8afc9f1