### PR TITLE
Support pinning to latest NixOS release tag and accept YY.MM flake inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,9 @@ nix build
 > **Tip:** To ensure the boot image targets the newest stable NixOS release,
 > run `scripts/update_nixos_stable.py` before building. The helper retargets
 > `flake.nix` and refreshes the `nixpkgs` lock entry to the latest
-> `nixos-YY.MM` channel available on GitHub.
+> `nixos-YY.MM` channel available on GitHub. To pin to the latest stable
+> release tag instead (for a less frequently moving baseline), run
+> `scripts/update_nixos_stable.py --latest-release`.
 
 ### Running flake checks locally
 

--- a/scripts/update_nixos_stable.py
+++ b/scripts/update_nixos_stable.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i python3 -p python3
-"""Update the repository to the latest stable NixOS channel.
+"""Update the repository to the latest stable NixOS channel or release tag.
 
 The script performs three steps:
 
-1. Query the GitHub API for nixpkgs branches and find the newest stable
-   "nixos-YY.MM" channel.
-2. Update ``flake.nix`` so that ``inputs.nixpkgs.url`` references that channel.
+1. Query the GitHub API for nixpkgs branches/tags and find either:
+   - the newest stable ``nixos-YY.MM`` channel branch (default), or
+   - the newest stable ``YY.MM`` release tag (``--latest-release`` mode).
+2. Update ``flake.nix`` so that ``inputs.nixpkgs.url`` references that target.
 3. Refresh ``flake.lock`` for the ``nixpkgs`` input.
 
 Requires network access and ``nix`` to be available in ``PATH``. Set
@@ -20,16 +21,19 @@ import os
 import re
 import subprocess
 import sys
+import argparse
 import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Iterable
 
 RE_CHANNEL = re.compile(r"^nixos-(\d{2})\.(\d{2})$")
+RE_RELEASE_TAG = re.compile(r"^(\d{2})\.(\d{2})$")
 RE_FLAKE_INPUT = re.compile(
-    r'(nixpkgs\.url\s*=\s*"github:NixOS/nixpkgs/)(nixos-\d{2}\.\d{2})(";)'
+    r'(nixpkgs\.url\s*=\s*"github:NixOS/nixpkgs/)(?:nixos-\d{2}\.\d{2}|\d{2}\.\d{2})(";)'
 )
 GITHUB_BRANCHES_URL = "https://api.github.com/repos/NixOS/nixpkgs/branches"
+GITHUB_TAGS_URL = "https://api.github.com/repos/NixOS/nixpkgs/tags"
 USER_AGENT = "nixos-boot-image-update-script"
 
 
@@ -67,6 +71,29 @@ def fetch_all_branches() -> list[str]:
     return branches
 
 
+def fetch_all_tags() -> list[str]:
+    tags: list[str] = []
+    page = 1
+    while True:
+        url = f"{GITHUB_TAGS_URL}?per_page=100&page={page}"
+        request = github_request(url)
+        try:
+            with urllib.request.urlopen(request) as response:
+                payload = response.read()
+        except urllib.error.HTTPError as exc:  # pragma: no cover - network failure
+            message = getattr(exc, "reason", exc)
+            raise SystemExit(f"GitHub API request failed: {message}")
+        except urllib.error.URLError as exc:  # pragma: no cover - network failure
+            raise SystemExit(f"Could not reach GitHub: {exc.reason}")
+
+        data = json.loads(payload)
+        if not data:
+            break
+        tags.extend(item["name"] for item in data)
+        page += 1
+    return tags
+
+
 def newest_stable_channel(branches: Iterable[str]) -> str:
     best_channel: tuple[int, int] | None = None
     best_name = None
@@ -84,10 +111,27 @@ def newest_stable_channel(branches: Iterable[str]) -> str:
     return best_name
 
 
+def newest_stable_release_tag(tags: Iterable[str]) -> str:
+    best_release: tuple[int, int] | None = None
+    best_name = None
+    for name in tags:
+        match = RE_RELEASE_TAG.match(name)
+        if not match:
+            continue
+        major, minor = map(int, match.groups())
+        version_tuple = (major, minor)
+        if best_release is None or version_tuple > best_release:
+            best_release = version_tuple
+            best_name = name
+    if best_name is None:
+        raise SystemExit("Could not determine the latest stable nixos release tag from GitHub tags.")
+    return best_name
+
+
 def update_flake_nix(path: Path, channel: str) -> None:
     original = path.read_text(encoding="utf-8")
     def replacement(match: re.Match[str]) -> str:
-        return f"{match.group(1)}{channel}{match.group(3)}"
+        return f"{match.group(1)}{channel}{match.group(2)}"
 
     updated, replacements = RE_FLAKE_INPUT.subn(replacement, original, count=1)
     if replacements == 0:
@@ -105,15 +149,29 @@ def run(*args: str, cwd: Path) -> None:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Update nixpkgs to the latest stable channel or release tag.")
+    parser.add_argument(
+        "--latest-release",
+        action="store_true",
+        help="Pin to the newest stable release tag (YY.MM) instead of the newest stable channel branch (nixos-YY.MM).",
+    )
+    args = parser.parse_args()
+
     repo_root = Path(__file__).resolve().parents[1]
-    print("Fetching nixpkgs branches from GitHub…", file=sys.stderr)
-    branches = fetch_all_branches()
-    channel = newest_stable_channel(branches)
-    print(f"Latest stable channel: {channel}", file=sys.stderr)
+    if args.latest_release:
+        print("Fetching nixpkgs tags from GitHub…", file=sys.stderr)
+        tags = fetch_all_tags()
+        target = newest_stable_release_tag(tags)
+        print(f"Latest stable release tag: {target}", file=sys.stderr)
+    else:
+        print("Fetching nixpkgs branches from GitHub…", file=sys.stderr)
+        branches = fetch_all_branches()
+        target = newest_stable_channel(branches)
+        print(f"Latest stable channel: {target}", file=sys.stderr)
 
     flake_path = repo_root / "flake.nix"
     print(f"Updating {flake_path}…", file=sys.stderr)
-    update_flake_nix(flake_path, channel)
+    update_flake_nix(flake_path, target)
 
     print("Updating flake.lock…", file=sys.stderr)
     run("nix", "flake", "update", "--update-input", "nixpkgs", cwd=repo_root)

--- a/tests/test_update_nixos_stable.py
+++ b/tests/test_update_nixos_stable.py
@@ -43,3 +43,27 @@ def test_update_flake_nix_requires_existing_entry(tmp_path, update_script):
 
     with pytest.raises(SystemExit):
         update_script.update_flake_nix(flake_nix, "nixos-25.05")
+
+
+def test_update_flake_nix_replaces_with_release_tag(tmp_path, update_script):
+    flake_nix = tmp_path / "flake.nix"
+    flake_nix.write_text(
+        """
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+  };
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    update_script.update_flake_nix(flake_nix, "25.05")
+
+    updated = flake_nix.read_text(encoding="utf-8")
+    assert 'nixpkgs.url = "github:NixOS/nixpkgs/25.05";' in updated
+
+
+def test_newest_stable_release_tag_selects_highest(update_script):
+    tags = ["release-16.03-start", "24.11", "23.11", "25.05", "v208"]
+    assert update_script.newest_stable_release_tag(tags) == "25.05"


### PR DESCRIPTION
### Motivation

- Allow the repository to be pinned to the latest stable NixOS release tag (YY.MM) in addition to the existing `nixos-YY.MM` channel branch. 
- Make `flake.nix` updates and the update helper tolerant of both channel branch names and plain release tags. 
- Document the new option in the README so users can pin to the latest stable release tag when desired.

### Description

- Add a `--latest-release` CLI flag to `scripts/update_nixos_stable.py` and parse it with `argparse` so callers can choose tag mode. 
- Implement `fetch_all_tags` and `newest_stable_release_tag` to query GitHub tags and select the newest `YY.MM` release. 
- Extend `RE_FLAKE_INPUT` to accept either `nixos-YY.MM` or `YY.MM` and fix the `update_flake_nix` replacement to use the correct regex group, plus route updates to the chosen `target`. 
- Update `README.md` with instructions to run `scripts/update_nixos_stable.py --latest-release` and add unit tests `test_update_flake_nix_replaces_with_release_tag` and `test_newest_stable_release_tag_selects_highest` in `tests/test_update_nixos_stable.py`.

### Testing

- Ran `pytest tests/test_update_nixos_stable.py` which executed the new and existing unit tests. 
- All tests in `tests/test_update_nixos_stable.py` passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee8c215ec4832f9ac3c60cb8246eec)